### PR TITLE
revise Gamma distribution used for sub-grid routing

### DIFF
--- a/build/source/engine/var_derive.f90
+++ b/build/source/engine/var_derive.f90
@@ -393,7 +393,7 @@ contains
  real(rkind)                        :: dt                     ! data time step (s)
  integer(i4b)                    :: nTDH                   ! number of points in the time-delay histogram
  integer(i4b)                    :: iFuture                ! index in time delay histogram
- real(rkind)                        :: aLambda                ! scale parameter in the Gamma distribution
+ real(rkind)                        :: routingGammaMean       ! mean of the Gamma distribution
  real(rkind)                        :: tFuture                ! future time (end of step)
  real(rkind)                        :: pSave                  ! cumulative probability at the start of the step
  real(rkind)                        :: cumProb                ! cumulative probability at the end of the step
@@ -433,8 +433,8 @@ contains
   case(timeDelay)
    ! initialize
    pSave   = 0._rkind ! cumulative probability at the start of the step
-   aLambda = routingGammaShape / routingGammaScale
-   if(routingGammaShape <= 0._rkind .or. aLambda < 0._rkind)then
+   routingGammaMean = routingGammaShape * routingGammaScale
+   if(routingGammaShape <= 0._rkind .or. routingGammaMean < 0._rkind)then
     message=trim(message)//'bad arguments for the Gamma distribution'
     err=20; return
    end if
@@ -442,7 +442,7 @@ contains
    do iFuture = 1,nTDH
     ! get weight for a given bin
     tFuture = real(iFuture, kind(dt))*dt                  ! future time (end of step)
-    cumProb = gammp(routingGammaShape,aLambda*tFuture)    ! cumulative probability at the end of the step
+    cumProb = gammp(routingGammaShape,tFuture*routingGammaShape/routingGammaMean)    ! cumulative probability at the end of the step
     fractionFuture(iFuture) = max(0._rkind, cumProb - pSave) ! fraction of runoff in the current step
     pSave   = cumProb                                     ! save the cumulative probability for use in the next step
     !write(*,'(a,1x,i4,1x,3(f20.10,1x))') trim(message), iFuture, tFuture, cumProb, fractionFuture(iFuture)

--- a/build/source/engine/var_derive.f90
+++ b/build/source/engine/var_derive.f90
@@ -393,7 +393,6 @@ contains
  real(rkind)                        :: dt                     ! data time step (s)
  integer(i4b)                    :: nTDH                   ! number of points in the time-delay histogram
  integer(i4b)                    :: iFuture                ! index in time delay histogram
- real(rkind)                        :: routingGammaMean       ! mean of the Gamma distribution
  real(rkind)                        :: tFuture                ! future time (end of step)
  real(rkind)                        :: pSave                  ! cumulative probability at the start of the step
  real(rkind)                        :: cumProb                ! cumulative probability at the end of the step
@@ -433,8 +432,7 @@ contains
   case(timeDelay)
    ! initialize
    pSave   = 0._rkind ! cumulative probability at the start of the step
-   routingGammaMean = routingGammaShape * routingGammaScale
-   if(routingGammaShape <= 0._rkind .or. routingGammaMean < 0._rkind)then
+   if(routingGammaShape <= 0._rkind .or. routingGammaScale <= 0._rkind)then
     message=trim(message)//'bad arguments for the Gamma distribution'
     err=20; return
    end if
@@ -442,7 +440,7 @@ contains
    do iFuture = 1,nTDH
     ! get weight for a given bin
     tFuture = real(iFuture, kind(dt))*dt                  ! future time (end of step)
-    cumProb = gammp(routingGammaShape,tFuture*routingGammaShape/routingGammaMean)    ! cumulative probability at the end of the step
+    cumProb = gammp(routingGammaShape,tFuture/routingGammaScale)    ! cumulative probability at the end of the step
     fractionFuture(iFuture) = max(0._rkind, cumProb - pSave) ! fraction of runoff in the current step
     pSave   = cumProb                                     ! save the cumulative probability for use in the next step
     !write(*,'(a,1x,i4,1x,3(f20.10,1x))') trim(message), iFuture, tFuture, cumProb, fractionFuture(iFuture)


### PR DESCRIPTION
Make sure all the relevant boxes are checked (and only check the box if you actually completed the step):

- [ ✓ ] closes #xxx (identify the issue associated with this PR)
- [ ✓ ] tests passed
- [ ✓ ] new tests added
- [ ✓ ] science test figures
- [ ✓ ] checked that the new code conforms to the [SUMMA coding conventions](https://github.com/NCAR/summa/blob/master/docs/howto/summa_coding_conventions.md)
- [ ] ReleaseNotes entry

The previous code has an error in calculating the cumulative probability "cumProb" of the Gamma distribution. Here the error is fixed by updating "sumProb" based on Equation 13 of Clark at el. (2007, WRR); removing variable "aLambda"; introducing variable "routingGammaMean".

The attached figures show the sensitivity of the updated Gamma distribution to the summa parameters routingGammaShape and routingGammaScale, respectively. 
![shape_sensitivity](https://user-images.githubusercontent.com/48458815/122324921-dff35c00-cee6-11eb-832d-446481ec52ce.png)
![scale_sensitivity](https://user-images.githubusercontent.com/48458815/122324917-dec22f00-cee6-11eb-881f-2ea5d062fd26.png)
