### PR TITLE
bugfix/sunGeomtry: solar angle during polar days

### DIFF
--- a/build/source/engine/sunGeomtry.f90
+++ b/build/source/engine/sunGeomtry.f90
@@ -108,8 +108,10 @@ contains
  TPI=-TAN(LP)*TAN(D)
  IF(ABS(TPI).LT.1.0) THEN
   TP=ACOS(TPI)
- ELSE
-  TP=0.0
+ ELSE IF(TPI.LT.-1.0) THEN ! 24h daylight
+  TP=ACOS(-1.0)
+ ELSE IF(TPI.GT.1.0) THEN ! 24h dark
+  TP=ACOS(1.0)
  ENDIF
  ! Calculate time adjustment for ground slope, aspect and latitude (DDT = 0 for level surface)
  DDT=ATAN(SIN(AZI1)*SIN(SLOPE1)/(COS(SLOPE1)*COS(LAT1)-COS(AZI1)*SIN(SLOPE1)*SIN(LAT1)))
@@ -150,8 +152,10 @@ contains
   TPI=-TAN(LP)*TAN(D)
   IF(ABS(TPI).LT.1.0) THEN
    TP=ACOS(TPI)
-  ELSE
-   TP=0.0
+  ELSE IF(TPI.LT.-1.0) THEN ! 24h daylight
+   TP=ACOS(-1.0)
+  ELSE IF(TPI.GT.1.0) THEN ! 24h dark
+   TP=ACOS(1.0)
   ENDIF
   ! Set beginning time to sunrise
   T1=MAX(-TP-DDT,-TD)

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -2,6 +2,9 @@
 
 This page provides simple, high-level documentation about what has changed in each new release of SUMMA.
 
+## Develop
+- Fixes a bug where solar angle incorrectly gets set to 0 during polar days
+
 ## Version 3.0.4 (pre-release)
 
 - Initial addition of the "What's new" page


### PR DESCRIPTION
Make sure all the relevant boxes are checked (and only check the box if you actually completed the step):

- [x] Follow-up of #390
- [x] tests passed
- [ ] new tests added
- [x] science test figures
- [x] checked that the new code conforms to the [SUMMA coding conventions](https://github.com/NCAR/summa/blob/master/docs/howto/summa_coding_conventions.md)
- [x] ReleaseNotes entry

## Issue
Variable `scalarCosZenith` (solar angle) gets incorrectly set to 0 during polar days. There should be no sunset, but solar angle = 0 implies the sun is constantly below the horizon; i.e. constant night.

## Test case 1
Left: `scalarCosZenith` before fixes. Solar angle = 0 (sun below horizon) for June and parts of July. Incoming shortwave shows that this is incorrect.

Right: `scalarCosZenith` after applied fixes. 

![image](https://user-images.githubusercontent.com/45757529/127743964-6cae391d-9dc3-4889-a312-2b545af6cf74.png)

## Test case 2
Fix applies to both hemispheres (top: Northern Hemisphere; bottom: Southern Hemisphere).

![image](https://user-images.githubusercontent.com/45757529/127744101-b14b9f63-1c03-4698-81c8-fc5a23e09031.png)

## Test case 3
All standard test cases complete bit for bit identical.

```
python check_bit_4_bit.py ./output/ ./output_new_summa/
Test   0 - Filename: celia1990_testSumma_timestep.nc                                  - Total difference: 0.0
Test   1 - Filename: colbeck1976-exp1_testSumma_timestep.nc                           - Total difference: 0.0
Test   2 - Filename: colbeck1976-exp2_testSumma_timestep.nc                           - Total difference: 0.0
Test   3 - Filename: colbeck1976-exp3_testSumma_timestep.nc                           - Total difference: 0.0
Test   4 - Filename: millerClay_testSumma_timestep.nc                                 - Total difference: 0.0
Test   5 - Filename: millerLoam_testSumma_timestep.nc                                 - Total difference: 0.0
Test   6 - Filename: millerSand_testSumma_timestep.nc                                 - Total difference: 0.0
Test   7 - Filename: mizoguchi1990_testSumma_timestep.nc                              - Total difference: 0.0
Test   8 - Filename: vanderborght2005_exp1_testSumma_timestep.nc                      - Total difference: 0.0
Test   9 - Filename: vanderborght2005_exp2_testSumma_timestep.nc                      - Total difference: 0.0
Test  10 - Filename: vanderborght2005_exp3_testSumma_timestep.nc                      - Total difference: 0.0
Test  11 - Filename: syntheticHillslope-exp1_testSumma_timestep.nc                    - Total difference: 0.0
Test  12 - Filename: syntheticHillslope-exp2_testSumma_timestep.nc                    - Total difference: 0.0
Test  13 - Filename: vegImpactsRad_riparianAspenBeersLaw_timestep.nc                  - Total difference: 0.0
Test  14 - Filename: vegImpactsRad_riparianAspenCLM2stream_timestep.nc                - Total difference: 0.0
Test  15 - Filename: vegImpactsRad_riparianAspenNLscatter_timestep.nc                 - Total difference: 0.0
Test  16 - Filename: vegImpactsRad_riparianAspenUEB2stream_timestep.nc                - Total difference: 0.0
Test  17 - Filename: vegImpactsRad_riparianAspenVegParamPerturb_timestep.nc           - Total difference: 0.0
Test  18 - Filename: vegImpactsWind_riparianAspenWindParamPerturb_timestep.nc         - Total difference: 0.0
Test  19 - Filename: vegImpactsWind_riparianAspenExpWindProfile_timestep.nc           - Total difference: 0.0
Test  20 - Filename: storckSite_hedpom9697_timestep.nc                                - Total difference: 0.0
Test  21 - Filename: storckSite_hedpom9798_timestep.nc                                - Total difference: 0.0
Test  22 - Filename: storckSite_storck9697_timestep.nc                                - Total difference: 0.0
Test  23 - Filename: storckSite_storck9798_timestep.nc                                - Total difference: 0.0
Test  24 - Filename: albedoTest_reynoldsConstantDecayRate_timestep.nc                 - Total difference: 0.0
Test  25 - Filename: albedoTest_reynoldsVariableDecayRate_timestep.nc                 - Total difference: 0.0
Test  26 - Filename: albedoTest_senatorConstantDecayRate_timestep.nc                  - Total difference: 0.0
Test  27 - Filename: albedoTest_senatorVariableDecayRate_timestep.nc                  - Total difference: 0.0
Test  28 - Filename: vegImpactsTranspire_ballBerry_timestep.nc                        - Total difference: 0.0
Test  29 - Filename: vegImpactsTranspire_jarvis_timestep.nc                           - Total difference: 0.0
Test  30 - Filename: vegImpactsTranspire_simpleResistance_timestep.nc                 - Total difference: 0.0
Test  31 - Filename: vegImpactsTranspire_perturbRoots_timestep.nc                     - Total difference: 0.0
Test  32 - Filename: basinRunoff_1dRichards_timestep.nc                               - Total difference: 0.0
Test  33 - Filename: basinRunoff_distributedTopmodel_timestep.nc                      - Total difference: 0.0
Test  34 - Filename: basinRunoff_lumpedTopmodel_timestep.nc                           - Total difference: 0.0
SUCCESSFUL TEST RUN: All files match!
```
