### PR TITLE
Fix scalarRainPlusMelt output

### DIFF
--- a/build/source/dshare/flxMapping.f90
+++ b/build/source/dshare/flxMapping.f90
@@ -143,7 +143,7 @@ contains
  flux2state_orig(iLookFLUX%mLayerLiqFluxSnow)               = flux2state(state1=iname_watLayer,  state2=integerMissing)
 
  ! liquid water fluxes for the soil domain
- flux2state_orig(iLookFLUX%scalarRainPlusMelt)              = flux2state(state1=iname_watLayer,  state2=integerMissing)
+ flux2state_orig(iLookFLUX%scalarRainPlusMelt)              = flux2state(state1=iname_matLayer,  state2=integerMissing)
  flux2state_orig(iLookFLUX%scalarMaxInfilRate)              = flux2state(state1=iname_matLayer,  state2=integerMissing)
  flux2state_orig(iLookFLUX%scalarInfiltration)              = flux2state(state1=iname_matLayer,  state2=integerMissing)
  flux2state_orig(iLookFLUX%scalarExfiltration)              = flux2state(state1=iname_matLayer,  state2=integerMissing)

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -19,3 +19,4 @@ This page provides simple, high-level documentation about what has changed in ea
 - Add deflate (compression level) option to outputControl file -- default level is 4 if not specified
 - Fixes an unnecessary rounding error on SAI and LAI values in PHENOLOGY routine
 - Fixes a bug where the SUMMA version is incorrectly reported by "summa.exe -v"
+- Fixes a bug that incorrectly writes scalarRainPlusMelt to output in cases where snow layers do not exist


### PR DESCRIPTION
The old code outputs scalarRainPlusMelt for the snow+soil layers only, which is incorrect for the no-snow period. The modified code outputs scalarRainPlusMelt for all the soil layers, enabling it works correctly for both the snow and no-snow periods.

Below is a comparison of summa outputs with the old and modified codes for one HRU in August 2000. In the 1st row, RainPlusMelt is almost zero in August which is incorrect because RainPlusMelt is supposed to be equal to Infiltration + SurfaceRunoff. In the 2nd row, the code is modified, and RainPlusMelt =  Infiltration + SurfaceRunoff.

![image](https://user-images.githubusercontent.com/48458815/154577064-7db44643-76b3-42da-9b8a-888559bafa0c.png)

<img width="1438" alt="Screen Shot 2022-02-17 at 2 38 15 PM" src="https://user-images.githubusercontent.com/48458815/154578213-2ad689ee-58cd-4400-8309-a42082a26939.png">

Make sure all the relevant boxes are checked (and only check the box if you actually completed the step):

- [ ] closes #xxx (identify the issue associated with this PR)
- [ ] tests passed
- [ ] new tests added
- [x] science test figures
- [x] checked that the new code conforms to the [SUMMA coding conventions](https://github.com/NCAR/summa/blob/master/docs/howto/summa_coding_conventions.md)
- [ ] ReleaseNotes entry
