### PR TITLE
Fix error message in check_icond.f90

### DIFF
--- a/build/source/engine/check_icond.f90
+++ b/build/source/engine/check_icond.f90
@@ -275,7 +275,7 @@ contains
     h1 = sum(progData%gru(iGRU)%hru(iHRU)%var(iLookPROG%mLayerDepth)%dat(1:iLayer)) ! sum of the depths up to the current layer
     h2 = progData%gru(iGRU)%hru(iHRU)%var(iLookPROG%iLayerHeight)%dat(iLayer) - progData%gru(iGRU)%hru(iHRU)%var(iLookPROG%iLayerHeight)%dat(0)  ! difference between snow-atm interface and bottom of layer
     if(abs(h1 - h2) > 1.e-6_rkind)then
-     write(message,'(a,1x,i0)') trim(message)//'mis-match between layer depth and layer height; layer = ', iLayer, '; sum depths = ',h1,'; height = ',h2
+     write(message,'(a,1x,i0,a,f5.3,a,f5.3)') trim(message)//'mis-match between layer depth and layer height; layer = ', iLayer, '; sum depths = ',h1,'; height = ',h2
      err=20; return
     end if
    end do

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -20,3 +20,4 @@ This page provides simple, high-level documentation about what has changed in ea
 - Fixes an unnecessary rounding error on SAI and LAI values in PHENOLOGY routine
 - Fixes a bug where the SUMMA version is incorrectly reported by "summa.exe -v"
 - Fixes a bug that incorrectly writes scalarRainPlusMelt to output in cases where snow layers do not exist
+- Changed part "(a,1x,i0)" to "(a,1x,i0,a,f5.3,a,f5.3)" in check_icond.f90 line 277 to print out error correctly.


### PR DESCRIPTION
Changed part '(a,1x,i0)' to '(a,1x,i0,a,f5.3,a,f5.3)' in check_icond.f90 line 277 to print out error correctly.

Make sure all the relevant boxes are checked (and only check the box if you actually completed the step):

- [ ] closes #xxx (identify the issue associated with this PR)
- [ ] tests passed
- [ ] new tests added
- [ ] science test figures
- [ ] checked that the new code conforms to the [SUMMA coding conventions](https://github.com/NCAR/summa/blob/master/docs/howto/summa_coding_conventions.md)
- [ ] ReleaseNotes entry
