### PR TITLE
update scalarSnowDrainage

### DIFF
--- a/build/source/engine/computFlux.f90
+++ b/build/source/engine/computFlux.f90
@@ -613,8 +613,9 @@ contains
   ! define forcing for the soil domain for the case of no snow layers
   ! NOTE: in case where nSnowOnlyHyd==0 AND snow layers exist, then scalarRainPlusMelt is taken from the previous flux evaluation
   if(nSnow==0)then
+   scalarSnowDrainage=drainageMeltPond/iden_water ! melt of the snow without a layer (m s-1)
    scalarRainPlusMelt = (scalarThroughfallRain + scalarCanopyLiqDrainage)/iden_water &  ! liquid flux from the canopy (m s-1)
-                         + drainageMeltPond/iden_water  ! melt of the snow without a layer (m s-1)
+                         + scalarSnowDrainage
   endif  ! if no snow layers
 
  endif

--- a/case_study/base_settings/localParamInfo.txt
+++ b/case_study/base_settings/localParamInfo.txt
@@ -1,3 +1,8 @@
+! File provenance
+! ---------------
+! 2021-08-10: taken from the SUMMA test cases v3 distribution (WRR figures) and included as case study default file
+!
+!
 ! =======================================================================================================================
 ! =======================================================================================================================
 ! ===== DEFINITION OF MODEL PARAMETERS ==================================================================================
@@ -45,7 +50,7 @@ fixedThermalCond_snow     |       0.3500 |       0.1000 |       1.0000
 ! snow albedo
 ! ====================================================================
 albedoMax                 |       0.8400 |       0.7000 |       0.9500
-albedoMinWinter           |       0.5500 |       0.5500 |       1.0000
+albedoMinWinter           |       0.5500 |       0.6000 |       1.0000
 albedoMinSpring           |       0.5500 |       0.3000 |       1.0000
 albedoMaxVisible          |       0.9500 |       0.7000 |       0.9500
 albedoMinVisible          |       0.7500 |       0.5000 |       0.7500
@@ -128,11 +133,11 @@ minStomatalConductance    |    2000.0000 |    2000.0000 |    2000.0000
 ! ====================================================================
 ! vegetation properties
 ! ====================================================================
-winterSAI                 |       0.5000 |       0.0100 |       3.0000
+winterSAI                 |       1.0000 |       0.0100 |       3.0000
 summerLAI                 |       3.0000 |       0.0100 |      10.0000
 rootScaleFactor1          |       2.0000 |       1.0000 |      10.0000
 rootScaleFactor2          |       5.0000 |       1.0000 |      10.0000
-rootingDepth              |       1.0000 |       0.0100 |      10.0000
+rootingDepth              |       2.0000 |       0.0100 |      10.0000
 rootDistExp               |       1.0000 |       0.0100 |       1.0000
 plantWiltPsi              |    -150.0000 |    -500.0000 |       0.0000
 soilStressParam           |       5.8000 |       4.3600 |       6.3700
@@ -142,7 +147,7 @@ critAquiferTranspire      |       0.2000 |       0.1000 |      10.0000
 minStomatalResistance     |      50.0000 |      10.0000 |     200.0000
 leafDimension             |       0.0400 |       0.0100 |       0.1000
 heightCanopyTop           |      20.0000 |       0.0500 |     100.0000
-heightCanopyBottom        |       2.0000 |       0.0000 |      15.0000
+heightCanopyBottom        |       2.0000 |       0.0000 |       5.0000
 specificHeatVeg           |     874.0000 |     500.0000 |    1500.0000
 maxMassVegetation         |      25.0000 |       1.0000 |      50.0000
 throughfallScaleSnow      |       0.5000 |       0.1000 |       0.9000
@@ -154,10 +159,6 @@ canopyDrainageCoeff       |       0.0050 |       0.0010 |       0.0100
 ratioDrip2Unloading       |       0.4000 |       0.0000 |       1.0000
 canopyWettingFactor       |       0.7000 |       0.0000 |       1.0000
 canopyWettingExp          |       1.0000 |       0.0000 |       1.0000
-minTempUnloading          |       270.16 |       260.16 |       273.16
-minWindUnloading          |       0.0000 |       0.0000 |       10.000
-rateTempUnloading         |      1.87d+5 |       1.0d+5 |       3.0d+5
-rateWindUnloading         |      1.56d+5 |       1.0d+5 |       3.0d+5
 ! ====================================================================
 ! soil properties
 ! ====================================================================
@@ -174,14 +175,14 @@ theta_res                 |       0.1390 |       0.0010 |       0.1000
 vGn_alpha                 |      -0.8400 |      -1.0000 |      -0.0100
 vGn_n                     |       1.3000 |       1.0000 |       3.0000
 mpExp                     |       5.0000 |       1.0000 |      10.0000
-k_soil                    |      7.5d-06 |       1.d-07 |       1.d-04
-k_macropore               |      1.0d-03 |       1.d-07 |       1.d-01
+k_soil                    |      7.5d-06 |       1.d-07 |     100.d-07
+k_macropore               |      1.0d-03 |       1.d-07 |     100.d-07
 kAnisotropic              |       1.0000 |       0.0001 |      10.0000
 zScale_TOPMODEL           |       2.5000 |       0.1000 |     100.0000
 compactedDepth            |       1.0000 |       0.0000 |       1.0000
-aquiferBaseflowRate       |       1.d-03 |       1.0d-9 |       0.1000
-aquiferScaleFactor        |       1.5000 |       0.1000 |      20.0000
+aquiferScaleFactor        |       0.3500 |       0.1000 |     100.0000
 aquiferBaseflowExp        |       2.0000 |       1.0000 |      10.0000
+aquiferBaseflowRate       |       2.0000 |       1.0000 |      10.0000
 qSurfScale                |      50.0000 |       1.0000 |     100.0000
 specificYield             |       0.2000 |       0.1000 |       0.3000
 specificStorage           |       1.d-09 |       1.d-05 |       1.d-07
@@ -193,17 +194,17 @@ soilIceCV                 |       0.4500 |       0.1000 |       5.0000
 ! ====================================================================
 minwind                   |       0.1000 |       0.0010 |       1.0000
 minstep                   |       1.0000 |       1.0000 |    1800.0000
-maxstep                   |    3600.0000 |      60.0000 |    3600.0000
+maxstep                   |    3600.0000 |      60.0000 |    1800.0000
 wimplicit                 |       0.0000 |       0.0000 |       1.0000
-maxiter                   |     300.0000 |       1.0000 |    1000.0000
+maxiter                   |     100.0000 |       1.0000 |     100.0000
 relConvTol_liquid         |       1.0d-3 |       1.0d-5 |       1.0d-1
-absConvTol_liquid         |       1.0d-4 |       1.0d-8 |       1.0d-3
-relConvTol_matric         |       1.0d-6 |       1.0d-7 |       1.0d-1
+absConvTol_liquid         |       1.0d-6 |       1.0d-8 |       1.0d-3
+relConvTol_matric         |       1.0d-6 |       1.0d-5 |       1.0d-1
 absConvTol_matric         |       1.0d-6 |       1.0d-8 |       1.0d-3
-relConvTol_aquifr         |       1.0d-1 |       1.0d-2 |       1.0d+1
-absConvTol_aquifr         |       1.0d-5 |       1.0d-5 |       1.0d-1
 relConvTol_energy         |       1.0d-2 |       1.0d-5 |       1.0d-1
-absConvTol_energy         |       1.0d-1 |       1.0d-2 |       1.0d+1
+absConvTol_energy         |       1.0d-0 |       1.0d-2 |       1.0d+1
+relConvTol_aquifr         |       1.0d-0 |       1.0d-2 |       1.0d+1
+absConvTol_aquifr         |       1.0d-5 |       1.0d-5 |       1.0d-1
 zmin                      |       0.0100 |       0.0050 |       0.1000
 zmax                      |       0.0500 |       0.0100 |       0.5000
 ! ---
@@ -223,3 +224,7 @@ zmaxLayer2_upper          |       0.1500 |       0.1500 |       0.1500
 zmaxLayer3_upper          |       0.3000 |       0.3000 |       0.3000
 zmaxLayer4_upper          |       0.7500 |       0.7500 |       0.7500
 ! ====================================================================
+minTempUnloading          |       270.16 |       260.16 |       273.16
+minWindUnloading          |       0.0000 |       0.0000 |       10.000
+rateTempUnloading         |      1.87d+5 |       1.0d+5 |       3.0d+5
+rateWindUnloading         |      1.56d+5 |       1.0d+5 |       3.0d+5

--- a/case_study/base_settings/localParamInfo.txt
+++ b/case_study/base_settings/localParamInfo.txt
@@ -1,8 +1,3 @@
-! File provenance
-! ---------------
-! 2021-08-10: taken from the SUMMA test cases v3 distribution (WRR figures) and included as case study default file
-!
-!
 ! =======================================================================================================================
 ! =======================================================================================================================
 ! ===== DEFINITION OF MODEL PARAMETERS ==================================================================================
@@ -50,7 +45,7 @@ fixedThermalCond_snow     |       0.3500 |       0.1000 |       1.0000
 ! snow albedo
 ! ====================================================================
 albedoMax                 |       0.8400 |       0.7000 |       0.9500
-albedoMinWinter           |       0.5500 |       0.6000 |       1.0000
+albedoMinWinter           |       0.5500 |       0.5500 |       1.0000
 albedoMinSpring           |       0.5500 |       0.3000 |       1.0000
 albedoMaxVisible          |       0.9500 |       0.7000 |       0.9500
 albedoMinVisible          |       0.7500 |       0.5000 |       0.7500
@@ -133,11 +128,11 @@ minStomatalConductance    |    2000.0000 |    2000.0000 |    2000.0000
 ! ====================================================================
 ! vegetation properties
 ! ====================================================================
-winterSAI                 |       1.0000 |       0.0100 |       3.0000
+winterSAI                 |       0.5000 |       0.0100 |       3.0000
 summerLAI                 |       3.0000 |       0.0100 |      10.0000
 rootScaleFactor1          |       2.0000 |       1.0000 |      10.0000
 rootScaleFactor2          |       5.0000 |       1.0000 |      10.0000
-rootingDepth              |       2.0000 |       0.0100 |      10.0000
+rootingDepth              |       1.0000 |       0.0100 |      10.0000
 rootDistExp               |       1.0000 |       0.0100 |       1.0000
 plantWiltPsi              |    -150.0000 |    -500.0000 |       0.0000
 soilStressParam           |       5.8000 |       4.3600 |       6.3700
@@ -147,7 +142,7 @@ critAquiferTranspire      |       0.2000 |       0.1000 |      10.0000
 minStomatalResistance     |      50.0000 |      10.0000 |     200.0000
 leafDimension             |       0.0400 |       0.0100 |       0.1000
 heightCanopyTop           |      20.0000 |       0.0500 |     100.0000
-heightCanopyBottom        |       2.0000 |       0.0000 |       5.0000
+heightCanopyBottom        |       2.0000 |       0.0000 |      15.0000
 specificHeatVeg           |     874.0000 |     500.0000 |    1500.0000
 maxMassVegetation         |      25.0000 |       1.0000 |      50.0000
 throughfallScaleSnow      |       0.5000 |       0.1000 |       0.9000
@@ -159,6 +154,10 @@ canopyDrainageCoeff       |       0.0050 |       0.0010 |       0.0100
 ratioDrip2Unloading       |       0.4000 |       0.0000 |       1.0000
 canopyWettingFactor       |       0.7000 |       0.0000 |       1.0000
 canopyWettingExp          |       1.0000 |       0.0000 |       1.0000
+minTempUnloading          |       270.16 |       260.16 |       273.16
+minWindUnloading          |       0.0000 |       0.0000 |       10.000
+rateTempUnloading         |      1.87d+5 |       1.0d+5 |       3.0d+5
+rateWindUnloading         |      1.56d+5 |       1.0d+5 |       3.0d+5
 ! ====================================================================
 ! soil properties
 ! ====================================================================
@@ -175,14 +174,14 @@ theta_res                 |       0.1390 |       0.0010 |       0.1000
 vGn_alpha                 |      -0.8400 |      -1.0000 |      -0.0100
 vGn_n                     |       1.3000 |       1.0000 |       3.0000
 mpExp                     |       5.0000 |       1.0000 |      10.0000
-k_soil                    |      7.5d-06 |       1.d-07 |     100.d-07
-k_macropore               |      1.0d-03 |       1.d-07 |     100.d-07
+k_soil                    |      7.5d-06 |       1.d-07 |       1.d-04
+k_macropore               |      1.0d-03 |       1.d-07 |       1.d-01
 kAnisotropic              |       1.0000 |       0.0001 |      10.0000
 zScale_TOPMODEL           |       2.5000 |       0.1000 |     100.0000
 compactedDepth            |       1.0000 |       0.0000 |       1.0000
-aquiferScaleFactor        |       0.3500 |       0.1000 |     100.0000
+aquiferBaseflowRate       |       1.d-03 |       1.0d-9 |       0.1000
+aquiferScaleFactor        |       1.5000 |       0.1000 |      20.0000
 aquiferBaseflowExp        |       2.0000 |       1.0000 |      10.0000
-aquiferBaseflowRate       |       2.0000 |       1.0000 |      10.0000
 qSurfScale                |      50.0000 |       1.0000 |     100.0000
 specificYield             |       0.2000 |       0.1000 |       0.3000
 specificStorage           |       1.d-09 |       1.d-05 |       1.d-07
@@ -194,17 +193,17 @@ soilIceCV                 |       0.4500 |       0.1000 |       5.0000
 ! ====================================================================
 minwind                   |       0.1000 |       0.0010 |       1.0000
 minstep                   |       1.0000 |       1.0000 |    1800.0000
-maxstep                   |    3600.0000 |      60.0000 |    1800.0000
+maxstep                   |    3600.0000 |      60.0000 |    3600.0000
 wimplicit                 |       0.0000 |       0.0000 |       1.0000
-maxiter                   |     100.0000 |       1.0000 |     100.0000
+maxiter                   |     300.0000 |       1.0000 |    1000.0000
 relConvTol_liquid         |       1.0d-3 |       1.0d-5 |       1.0d-1
-absConvTol_liquid         |       1.0d-6 |       1.0d-8 |       1.0d-3
-relConvTol_matric         |       1.0d-6 |       1.0d-5 |       1.0d-1
+absConvTol_liquid         |       1.0d-4 |       1.0d-8 |       1.0d-3
+relConvTol_matric         |       1.0d-6 |       1.0d-7 |       1.0d-1
 absConvTol_matric         |       1.0d-6 |       1.0d-8 |       1.0d-3
-relConvTol_energy         |       1.0d-2 |       1.0d-5 |       1.0d-1
-absConvTol_energy         |       1.0d-0 |       1.0d-2 |       1.0d+1
-relConvTol_aquifr         |       1.0d-0 |       1.0d-2 |       1.0d+1
+relConvTol_aquifr         |       1.0d-1 |       1.0d-2 |       1.0d+1
 absConvTol_aquifr         |       1.0d-5 |       1.0d-5 |       1.0d-1
+relConvTol_energy         |       1.0d-2 |       1.0d-5 |       1.0d-1
+absConvTol_energy         |       1.0d-1 |       1.0d-2 |       1.0d+1
 zmin                      |       0.0100 |       0.0050 |       0.1000
 zmax                      |       0.0500 |       0.0100 |       0.5000
 ! ---
@@ -224,7 +223,3 @@ zmaxLayer2_upper          |       0.1500 |       0.1500 |       0.1500
 zmaxLayer3_upper          |       0.3000 |       0.3000 |       0.3000
 zmaxLayer4_upper          |       0.7500 |       0.7500 |       0.7500
 ! ====================================================================
-minTempUnloading          |       270.16 |       260.16 |       273.16
-minWindUnloading          |       0.0000 |       0.0000 |       10.000
-rateTempUnloading         |      1.87d+5 |       1.0d+5 |       3.0d+5
-rateWindUnloading         |      1.56d+5 |       1.0d+5 |       3.0d+5

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -22,4 +22,3 @@ This page provides simple, high-level documentation about what has changed in ea
 - Fixes a bug that incorrectly writes scalarRainPlusMelt to output in cases where snow layers do not exist
 - Changed part "(a,1x,i0)" to "(a,1x,i0,a,f5.3,a,f5.3)" in check_icond.f90 line 277 to print out error correctly.
 - Adds scalarSnowDrainage calculation when melt of the snow without a layer
-- update localParamInfo.txt in base_settings/base_settings

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -21,3 +21,5 @@ This page provides simple, high-level documentation about what has changed in ea
 - Fixes a bug where the SUMMA version is incorrectly reported by "summa.exe -v"
 - Fixes a bug that incorrectly writes scalarRainPlusMelt to output in cases where snow layers do not exist
 - Changed part "(a,1x,i0)" to "(a,1x,i0,a,f5.3,a,f5.3)" in check_icond.f90 line 277 to print out error correctly.
+- Adds scalarSnowDrainage calculation when melt of the snow without a layer
+- update localParamInfo.txt in base_settings/base_settings


### PR DESCRIPTION

Make sure all the relevant boxes are checked (and only check the box if you actually completed the step):

- [ ] Closes #xxx (identify the issue associated with this PR)
- [x] Code passes standard test cases (results are either bit-for-bit identical, or differences are explained in the PR comment)
- [ ] New tests added (describe which tests were performed to test the changes)
- [ ] Science test figures (add figures to PR comment and describe the tests)
- [x] Checked that the new code conforms to the [SUMMA coding conventions](https://github.com/NCAR/summa/blob/master/docs/howto/summa_coding_conventions.md)
- [x] Describe the change in the release notes (use either `./summa/docs/whats-new.md` or `./summa/docs/minor-changes.md` depending on what changed)



1. `scalarSnowDrainage=drainageMeltPond/iden_water` is added when` nSnow==0` according to Martyn's suggestion.
2. The localParamInfo.txt in the case_study is updated. Compared with the old localParamInfo.txt, the new localParamInfo.txt has several parameter initial and bound values changes made by Andy Wood, which can help achieve better model performances. Besides, I changed the upper bounds of k_soil and heightCanopyBottom explained as below. The increased upper bounds allow appropriate parameter range in calibration.
(1) In TBL_SOILPARM.TBL (Soil Parameters: ROSETTA), the k_soil is up to 7.43852e-05 for 'SAND'. Therefore, **the upper bound of k_soil is increased from 100.d-07 to 1.d-04** in the localParamInfo.txt.
(2) In TBL_VEGPARM.TBL, for MODIFIED_IGBP_MODIS_NOAH, ZBOTV is up to 11.5 for 'Deciduous Broadleaf Forest'; for USGS, ZBOTV is up to 11.5 for 'Deciduous Broadleaf Forest' and 'Wooded Wetland'. Therefore, **the upper bound of heightCanopyBottom is increased from 5.0000 to 15.000** in the localParamInfo.txt.
