### PR TITLE
Update var_lookup.f90 to add wallClockTime.

### DIFF
--- a/build/source/dshare/var_lookup.f90
+++ b/build/source/dshare/var_lookup.f90
@@ -437,6 +437,7 @@ MODULE var_lookup
   integer(i4b)    :: scalarVolLatHt_fus              = integerMissing ! volumetric latent heat of fusion     (J m-3)
   ! number of function evaluations
   integer(i4b)    :: numFluxCalls                    = integerMissing ! number of flux calls (-)
+  integer(i4b)    :: wallClockTime                   = integerMissing ! wall clock time (s)
  endtype iLook_diag
 
  ! ***********************************************************************************************************


### PR DESCRIPTION
To correct an issue where running SUMMA without this correction fails due to fatal error.

<img width="1114" alt="Screenshot 2023-01-27 at 5 48 51 PM" src="https://user-images.githubusercontent.com/60660437/215521567-7bba2ff1-f409-4479-b7f1-079e525094f7.png">



Make sure all the relevant boxes are checked (and only check the box if you actually completed the step):

- [ ] Closes #xxx (identify the issue associated with this PR)
- [ ] Code passes standard test cases (results are either bit-for-bit identical, or differences are explained in the PR comment)
- [ ] New tests added (describe which tests were performed to test the changes)
- [ ] Science test figures (add figures to PR comment and describe the tests)
- [x] Checked that the new code conforms to the [SUMMA coding conventions](https://github.com/NCAR/summa/blob/master/docs/howto/summa_coding_conventions.md)
- [ ] Describe the change in the release notes (use either `./summa/docs/whats-new.md` or `./summa/docs/minor-changes.md` depending on what changed)
