### PR TITLE
Atmospheric Stability formula correction for `standard` method

### DIFF
--- a/build/source/engine/vegNrgFlux.f90
+++ b/build/source/engine/vegNrgFlux.f90
@@ -3188,7 +3188,7 @@ contains
   ! ("standard" stability correction, a la Anderson 1976)
   case(standard)
    ! compute surface-atmosphere exchange coefficient (-)
-   if(RiBulk <  critRichNumber) stabilityCorrection = (1._rkind - 5._rkind*RiBulk)**2._rkind
+   if(RiBulk <  critRichNumber) stabilityCorrection = (1._rkind - 5._rkind*RiBulk)**(-1._rkind)
    if(RiBulk >= critRichNumber) stabilityCorrection = verySmall
    ! compute derivative in surface-atmosphere exchange coefficient w.r.t. temperature (K-1)
    if(computeDerivative)then

--- a/docs/minor-changes.md
+++ b/docs/minor-changes.md
@@ -11,4 +11,4 @@ Documented here are minor changes that do not affect science outputs or are like
 
 ## Version 3.0.4 (pre-release)
 
-- [placeholder]
+- Formula correction of `stabalityCorrection` calculation for `standard` method


### PR DESCRIPTION
Make sure all the relevant boxes are checked (and only check the box if you actually completed the step):

- [ ] Closes #xxx (identify the issue associated with this PR)
- [x] Code passes standard test cases (results are either bit-for-bit identical, or differences are explained in the PR comment)
- [ ] New tests added (describe which tests were performed to test the changes)
- [ ] Science test figures (add figures to PR comment and describe the tests)
- [x] Checked that the new code conforms to the [SUMMA coding conventions](https://github.com/NCAR/summa/blob/master/docs/howto/summa_coding_conventions.md)
- [x] Describe the change in the release notes (use either `./summa/docs/whats-new.md` or `./summa/docs/minor-changes.md` depending on what changed)

I got stabality correction formula as below in the [`Anderson (1976)` paper](https://www.proquest.com/docview/302818861?pq-origsite=gscholar&fromopenview=true).

![image](https://user-images.githubusercontent.com/39838116/232912028-13bc9c78-5c90-49e0-b943-0289bcc92ee6.png)
