### PR TITLE
Summa-Actors compatibility update

### DIFF
--- a/build/source/driver/summa_modelRun.f90
+++ b/build/source/driver/summa_modelRun.f90
@@ -56,6 +56,7 @@ contains
  USE globalData,only:model_decisions                            ! model decision structure
  USE globalData,only:startPhysics,endPhysics                    ! date/time for the start and end of the initialization
  USE globalData,only:elapsedPhysics                             ! elapsed time for the initialization
+ USE globalData,only:fracJulDay,yearLength
  ! ---------------------------------------------------------------------------------------
  ! * variables
  ! ---------------------------------------------------------------------------------------
@@ -129,6 +130,8 @@ contains
     call vegPhenlgy(&
                     ! input/output: data structures
                     model_decisions,                & ! intent(in):    model decisions
+                    fracJulDay,                     & ! intent(in):    fraction of julian day
+                    yearLength,                     & ! intent(in):    length of the year
                     typeStruct%gru(iGRU)%hru(iHRU), & ! intent(in):    type of vegetation and soil
                     attrStruct%gru(iGRU)%hru(iHRU), & ! intent(in):    spatial attributes
                     mparStruct%gru(iGRU)%hru(iHRU), & ! intent(in):    model parameters

--- a/build/source/engine/coupled_em.f90
+++ b/build/source/engine/coupled_em.f90
@@ -232,20 +232,20 @@ contains
  real(rkind)                             :: balanceAquifer0        ! total aquifer storage at the start of the step (kg m-2)
  real(rkind)                             :: balanceAquifer1        ! total aquifer storage at the end of the step (kg m-2)
  ! test balance checks
- logical(lgt), parameter              :: printBalance=.false.   ! flag to print the balance checks
+ logical(lgt), parameter              :: printBalance=.false.      ! flag to print the balance checks
  real(rkind), allocatable                :: liqSnowInit(:)         ! volumetric liquid water conetnt of snow at the start of the time step
  real(rkind), allocatable                :: liqSoilInit(:)         ! soil moisture at the start of the time step
  ! timing information
- real(rkind)                             :: startTime              ! start time (used to compute wall clock time)
- real(rkind)                             :: endTime                ! end time (used to compute wall clock time)
+ integer(kind=8)                         :: count_rate
+ integer(kind=8)                         :: startTime              ! start time (used to compute wall clock time)
+ integer(kind=8)                         :: endTime                ! end time (used to compute wall clock time)
  ! ----------------------------------------------------------------------------------------------------------------------------------------------
  ! initialize error control
  err=0; message="coupled_em/"
 
  ! This is the start of a data step for a local HRU
-
  ! get the start time
- call cpu_time(startTime)
+ call system_clock(count=startTime, count_rate=count_rate)
 
  ! check the sundials decision
  if(model_decisions(iLookDECISIONS%num_method)%iDecision==sundials)then
@@ -1233,10 +1233,10 @@ contains
  end if
 
  ! get the end time
- call cpu_time(endTime)
+ call system_clock(endTime)
 
  ! get the elapsed time
- diag_data%var(iLookDIAG%wallClockTime)%dat(1) = endTime - startTime
+ diag_data%var(iLookDIAG%wallClockTime)%dat(1) = REAL(endTime - startTime) / REAL(count_rate)
 
  end subroutine coupled_em
 

--- a/build/source/engine/coupled_em.f90
+++ b/build/source/engine/coupled_em.f90
@@ -102,7 +102,10 @@ contains
                        ! model control
                        hruId,             & ! intent(in):    hruId
                        dt_init,           & ! intent(inout): used to initialize the size of the sub-step
+                       dt_init_factor,    & ! intent(in):    Used to adjust the length of the timestep in event of HRU failure (Summa-Actors feature)
                        computeVegFlux,    & ! intent(inout): flag to indicate if we are computing fluxes over vegetation (.false. means veg is buried with snow)
+                       fracJulDay,        & ! intent(in):    fraction of the Julian day
+                       yearLength,        & ! intent(in):    length of the year (days)
                        ! data structures (input)
                        type_data,         & ! intent(in):    local classification of soil veg etc. for each HRU
                        attr_data,         & ! intent(in):    local attributes for each HRU
@@ -143,7 +146,10 @@ contains
  implicit none
  ! model control
  integer(8),intent(in)                :: hruId                  ! hruId
- real(rkind),intent(inout)               :: dt_init                ! used to initialize the size of the sub-step
+ real(rkind),intent(inout)            :: dt_init                ! used to initialize the size of the sub-step
+ integer(i4b),intent(in)              :: dt_init_factor         ! Used to adjust the length of the timestep in event of HRU failure (Summa-Actors feature)
+ real(rkind),intent(in)               :: fracJulDay             ! fraction of the Julian day
+ integer(i4b),intent(in)              :: yearLength             ! length of the year (days)
  logical(lgt),intent(inout)           :: computeVegFlux         ! flag to indicate if we are computing fluxes over vegetation (.false. means veg is buried with snow)
  ! data structures (input)
  type(var_i),intent(in)               :: type_data              ! type of vegetation and soil
@@ -394,6 +400,8 @@ contains
  call vegPhenlgy(&
                  ! input/output: data structures
                  model_decisions,             & ! intent(in):    model decisions
+                 fracJulDay,                  & ! intent(in):    fraction of julian day
+                 yearLength,                  & ! intent(in):    length of the year
                  type_data,                   & ! intent(in):    type of vegetation and soil
                  attr_data,                   & ! intent(in):    spatial attributes
                  mpar_data,                   & ! intent(in):    model parameters
@@ -553,7 +561,7 @@ contains
 
  ! initialize the length of the sub-step
  dt_solv = 0._rkind   ! length of time step that has been completed (s)
- dt_init = min(data_step,maxstep)  ! initial substep length (s)
+ dt_init = min(data_step,maxstep) / dt_init_factor ! initial substep length (s)
  dt_sub  = dt_init                 ! length of substep
  dtSave  = dt_init                 ! length of substep
 

--- a/build/source/engine/derivforce.f90
+++ b/build/source/engine/derivforce.f90
@@ -33,7 +33,6 @@ USE multiconst,only:minprhour                               ! number of minutes 
 ! global time information
 USE globalData,only:refJulday                               ! reference time (fractional julian days)
 USE globalData,only:data_step                               ! length of the data step (s)
-USE globalData,only:tmZoneOffsetFracDay                     ! time zone offset in fractional days
 
 ! model decisions
 USE globalData,only:model_decisions                         ! model decision structure
@@ -63,7 +62,7 @@ contains
  ! ************************************************************************************************
  ! public subroutine derivforce: compute derived forcing data
  ! ************************************************************************************************
- subroutine derivforce(time_data,forc_data,attr_data,mpar_data,prog_data,diag_data,flux_data,err,message)
+ subroutine derivforce(time_data,forc_data,attr_data,mpar_data,prog_data,diag_data,flux_data,tmZoneOffsetFracDay,err,message)
  USE sunGeomtry_module,only:clrsky_rad                       ! compute cosine of the solar zenith angle
  USE conv_funcs_module,only:vapPress                         ! compute vapor pressure of air (Pa)
  USE conv_funcs_module,only:SPHM2RELHM,RELHM2SPHM,WETBULBTMP ! conversion functions
@@ -81,6 +80,7 @@ contains
  ! output variables
  type(var_dlength),intent(inout) :: diag_data                ! data structure of model diagnostic variables for a local HRU
  type(var_dlength),intent(inout) :: flux_data                ! data structure of model fluxes for a local HRU
+ real(rkind),intent(inout)       :: tmZoneOffsetFracDay      ! time zone offset in 
  integer(i4b),intent(out)        :: err                      ! error code
  character(*),intent(out)        :: message                  ! error message
  ! local time

--- a/build/source/engine/read_param.f90
+++ b/build/source/engine/read_param.f90
@@ -357,6 +357,10 @@ contains
 
  end do ! (looping through the parameters in the NetCDF file)
 
+  ! close the netcdf file
+  call nc_file_close(ncid, err, cmessage)
+  if(err/=0)then; message=trim(message)//trim(cmessage); return; end if
+
  end subroutine read_param
 
 end module read_param_module

--- a/build/source/engine/run_oneHRU.f90
+++ b/build/source/engine/run_oneHRU.f90
@@ -104,7 +104,7 @@ contains
                        err,message)           ! intent(out):   error control
 
  ! ----- define downstream subroutines -----------------------------------------------------------------------------------
-
+ USE globalData,only:fracJulDay,yearLength,tmZoneOffsetFracDay   ! fraction of julian day and length of year (Summa-Actors has these as local vars)
  USE module_sf_noahmplsm,only:redprm          ! module to assign more Noah-MP parameters
  USE derivforce_module,only:derivforce        ! module to compute derived forcing data
  USE coupled_em_module,only:coupled_em        ! module to run the coupled energy and mass model
@@ -136,6 +136,7 @@ contains
  ! ----- define local variables ------------------------------------------------------------------------------------------
 
  ! local variables
+ integer(i4b)                      :: dt_init_factor=1    ! factor to divide dt_init by (Summa-Actors feature) 1 keeps Summa's original behavior
  character(len=256)                :: cmessage            ! error message
  real(rkind)          , allocatable   :: zSoilReverseSign(:) ! height at bottom of each soil layer, negative downwards (m)
 
@@ -188,13 +189,14 @@ contains
  ! ----- hru forcing ----------------------------------------------------------------------------------------------------
 
  ! compute derived forcing variables
- call derivforce(timeVec,          & ! vector of time information
-                 forcData%var,     & ! vector of model forcing data
-                 attrData%var,     & ! vector of model attributes
-                 mparData,         & ! data structure of model parameters
-                 progData,         & ! data structure of model prognostic variables
-                 diagData,         & ! data structure of model diagnostic variables
-                 fluxData,         & ! data structure of model fluxes
+ call derivforce(timeVec,            & ! vector of time information
+                 forcData%var,       & ! vector of model forcing data
+                 attrData%var,       & ! vector of model attributes
+                 mparData,           & ! data structure of model parameters
+                 progData,           & ! data structure of model prognostic variables
+                 diagData,           & ! data structure of model diagnostic variables
+                 fluxData,           & ! data structure of model fluxes
+                 tmZoneOffsetFracDay,& ! time zone offset in fraction of day
                  err,cmessage)       ! error control
  if(err/=0)then; err=20; message=trim(message)//trim(cmessage); return; endif
 
@@ -208,7 +210,10 @@ contains
                  ! model control
                  hruId,            & ! intent(in):    hruId
                  dt_init,          & ! intent(inout): initial time step
+                 dt_init_factor,   & ! intent(in):    factor to divide dt_init by (Summa-Actors feature)
                  computeVegFlux,   & ! intent(inout): flag to indicate if we are computing fluxes over vegetation
+                 fracJulDay,       & ! intent(in):    fraction of julian day
+                 yearLength,       & ! intent(in):    length of year
                  ! data structures (input)
                  typeData,         & ! intent(in):    local classification of soil veg etc. for each HRU
                  attrData,         & ! intent(in):    local attributes for each HRU

--- a/build/source/engine/varSubstep.f90
+++ b/build/source/engine/varSubstep.f90
@@ -197,7 +197,7 @@ contains
  logical(lgt)                    :: firstSplitOper                ! flag to indicate if we are processing the first flux call in a splitting operation
  logical(lgt)                    :: checkMassBalance              ! flag to check the mass balance
  logical(lgt)                    :: waterBalanceError             ! flag to denote that there is a water balance error
- logical(lgt)                    :: nrgFluxModified               ! flag to denote that the energy fluxes were modified
+ logical(lgt)                    :: nrgFluxModified=.false.       ! flag to denote that the energy fluxes were modified
  ! energy fluxes
  real(rkind)                        :: sumCanopyEvaporation          ! sum of canopy evaporation/condensation (kg m-2 s-1)
  real(rkind)                        :: sumLatHeatCanopyEvap          ! sum of latent heat flux for evaporation from the canopy to the canopy air space (W m-2)

--- a/build/source/engine/vegPhenlgy.f90
+++ b/build/source/engine/vegPhenlgy.f90
@@ -25,8 +25,6 @@ USE nrtype
 
 ! global variables
 USE globalData,only:urbanVegCategory    ! vegetation category for urban areas
-USE globalData,only:fracJulday          ! fractional julian days since the start of year
-USE globalData,only:yearLength          ! number of days in the current year
 
 ! provide access to the derived types to define the data structures
 USE data_types,only:&
@@ -69,6 +67,8 @@ contains
  subroutine vegPhenlgy(&
                        ! input/output: data structures
                        model_decisions,             & ! intent(in):    model decisions
+                       fracJulDay,                  & ! intent(in):    fractional julian days since the start of year
+                       yearLength,                  & ! intent(in):    length of the year
                        type_data,                   & ! intent(in):    type of vegetation and soil
                        attr_data,                   & ! intent(in):    spatial attributes
                        mpar_data,                   & ! intent(in):    model parameters
@@ -86,6 +86,8 @@ contains
  ! -------------------------------------------------------------------------------------------------
  ! input/output
  type(model_options),intent(in)  :: model_decisions(:)  ! model decisions
+ real(rkind),intent(in)          :: fracJulDay          ! fractional julian days since the start of year
+ integer(i4b),intent(in)         :: yearLength          ! days in current year
  type(var_i),intent(in)          :: type_data           ! type of vegetation and soil
  type(var_d),intent(in)          :: attr_data           ! spatial attributes
  type(var_dlength),intent(in)    :: mpar_data           ! model parameters

--- a/build/source/netcdf/read_icond.f90
+++ b/build/source/netcdf/read_icond.f90
@@ -461,6 +461,9 @@ contains
   endif  ! end if case for tdh variables being in init. cond. file
  endif  ! end if case for not being a singleHRU run
 
+ call nc_file_close(ncID,err,cmessage)
+  if(err/=0)then; message=trim(message)//trim(cmessage); return; end if
+
  end subroutine read_icond
 
 end module read_icond_module


### PR DESCRIPTION
Adjusted where fracJulDay, yearLength, and tmZoneOffsetFracDay are imported from globalData. I also moved them as arguments to the subroutines they were used in. 

This is because our Summa-Actors project (https://git.cs.usask.ca/numerical_simulations_lab/actors/Summa-Actors) has these variables local to the "HRU_Actor" so it can be computed asynchronously. These changes allow Summa-Actors to import the majority of these existing files without modification or keeping its own copy. This way any changes made in this repo are automatically reflected in Summa-Actors.

The changes requested here do not change any functionality and were tested with the following laugh-tests:
- celia1990
- colbeck1976 (1, 2, 3)
- mizoguchi1990
- vanderborght2005 (1, 2, 3)

The changes made in the pull request produced the exact results from the current main branch. 

Additionally changed the cpu_time function call to system_clock. This is because system_clock is thread safe. When multithreading (Summa-Actors) cpu_time() does not produce correct results for each HRU where system_clock does.