### PR TITLE
Implementation of HDS in SUMMA

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ Makefile-*
 *.backup
 # site directory from mkdocs
 site/
+# vscode setting files
+.vscode

--- a/build/Makefile
+++ b/build/Makefile
@@ -216,6 +216,7 @@ SUMMA_SOLVER= \
 		opSplittin.f90 \
 		coupled_em.f90 \
 		run_oneHRU.f90 \
+		HDS.f90 \
 		run_oneGRU.f90
 SOLVER = $(patsubst %, $(ENGINE_DIR)/%, $(SUMMA_SOLVER))
 

--- a/build/source/driver/.gitignore
+++ b/build/source/driver/.gitignore
@@ -1,1 +1,0 @@
-summaversion.inc

--- a/build/source/driver/summa_modelRun.f90
+++ b/build/source/driver/summa_modelRun.f90
@@ -152,19 +152,6 @@ contains
     diagStruct%gru(iGRU)%hru(iHRU)%var(iLookDIAG%scalarGreenVegFraction)%dat(1) = greenVegFrac_monthly(timeStruct%var(iLookTIME%im))
 
    end do  ! looping through HRUs
-   ! *****************************************************************************
-   ! *** initialize HDS variables at the GRU level
-   ! *****************************************************************************
-  !  call init_summa_HDS(bparStruct%gru(iGRU)%var(iLookBVAR%pondVolFrac), &
-  !                      bparStruct%gru(iGRU)%var(iLookBPAR%depressionDepth), &
-  !                      bparStruct%gru(iGRU)%var(iLookBPAR%depressionAreaFrac), &
-  !                      bvarStruct%gru(iGRU)%var(iLookBVAR%basin__totalArea)%dat(1), &
-  !                      bparStruct%gru(iGRU)%var(iLookBPAR%depression_p), &
-  !                      bparStruct%gru(iGRU)%var(iLookBVAR%pondVol), &
-  !                      bparStruct%gru(iGRU)%var(iLookBVAR%pondArea), &
-  !                      bparStruct%gru(iGRU)%var(iLookBVAR%conArea), & 
-  !                      bparStruct%gru(iGRU)%var(iLookBVAR%vMin))
-
   end do  ! looping through GRUs
  end if  ! if the first time step
 

--- a/build/source/driver/summa_modelRun.f90
+++ b/build/source/driver/summa_modelRun.f90
@@ -30,6 +30,8 @@ USE globalData,only:yes,no           ! .true. and .false.
 USE var_lookup,only:iLookTIME        ! named variables for time data structure
 USE var_lookup,only:iLookDIAG        ! look-up values for local column model diagnostic variables
 USE var_lookup,only:iLookINDEX       ! look-up values for local column index variables
+! USE var_lookup,only:iLookBPAR        ! look-up values for basin parameters (used for HDS initialization)
+! USE var_lookup,only:iLookBVAR        ! look-up values for basin variables (used for HDS initialization)
 USE summa_util,only:handle_err
 
 ! safety: set private unless specified otherwise
@@ -51,6 +53,7 @@ contains
  USE vegPhenlgy_module,only:vegPhenlgy                          ! module to compute vegetation phenology
  USE run_oneGRU_module,only:run_oneGRU                          ! module to run for one GRU
  USE time_utils_module,only:elapsedSec                          ! calculate the elapsed time
+!  USE HDS,only:init_summa_HDS                                    ! initialize HDS variables for the first time step
  ! global data
  USE globalData,only:gru_struc                                  ! gru-hru mapping structures
  USE globalData,only:model_decisions                            ! model decision structure
@@ -149,6 +152,19 @@ contains
     diagStruct%gru(iGRU)%hru(iHRU)%var(iLookDIAG%scalarGreenVegFraction)%dat(1) = greenVegFrac_monthly(timeStruct%var(iLookTIME%im))
 
    end do  ! looping through HRUs
+   ! *****************************************************************************
+   ! *** initialize HDS variables at the GRU level
+   ! *****************************************************************************
+  !  call init_summa_HDS(bparStruct%gru(iGRU)%var(iLookBVAR%pondVolFrac), &
+  !                      bparStruct%gru(iGRU)%var(iLookBPAR%depressionDepth), &
+  !                      bparStruct%gru(iGRU)%var(iLookBPAR%depressionAreaFrac), &
+  !                      bvarStruct%gru(iGRU)%var(iLookBVAR%basin__totalArea)%dat(1), &
+  !                      bparStruct%gru(iGRU)%var(iLookBPAR%depression_p), &
+  !                      bparStruct%gru(iGRU)%var(iLookBVAR%pondVol), &
+  !                      bparStruct%gru(iGRU)%var(iLookBVAR%pondArea), &
+  !                      bparStruct%gru(iGRU)%var(iLookBVAR%conArea), & 
+  !                      bparStruct%gru(iGRU)%var(iLookBVAR%vMin))
+
   end do  ! looping through GRUs
  end if  ! if the first time step
 
@@ -250,6 +266,7 @@ contains
                   typeStruct%gru(iGRU),         & ! intent(in):    local classification of soil veg etc. for each HRU
                   idStruct%gru(iGRU),           & ! intent(in):    local classification of soil veg etc. for each HRU
                   attrStruct%gru(iGRU),         & ! intent(in):    local attributes for each HRU
+                  bparStruct%gru(iGRU),         & ! intent(in):    basin-average parameters for HDS 
                   ! data structures (input-output)
                   mparStruct%gru(iGRU),         & ! intent(inout): local model parameters
                   indxStruct%gru(iGRU),         & ! intent(inout): model indices

--- a/build/source/driver/summa_modelRun.f90
+++ b/build/source/driver/summa_modelRun.f90
@@ -30,8 +30,6 @@ USE globalData,only:yes,no           ! .true. and .false.
 USE var_lookup,only:iLookTIME        ! named variables for time data structure
 USE var_lookup,only:iLookDIAG        ! look-up values for local column model diagnostic variables
 USE var_lookup,only:iLookINDEX       ! look-up values for local column index variables
-! USE var_lookup,only:iLookBPAR        ! look-up values for basin parameters (used for HDS initialization)
-! USE var_lookup,only:iLookBVAR        ! look-up values for basin variables (used for HDS initialization)
 USE summa_util,only:handle_err
 
 ! safety: set private unless specified otherwise
@@ -53,7 +51,6 @@ contains
  USE vegPhenlgy_module,only:vegPhenlgy                          ! module to compute vegetation phenology
  USE run_oneGRU_module,only:run_oneGRU                          ! module to run for one GRU
  USE time_utils_module,only:elapsedSec                          ! calculate the elapsed time
-!  USE HDS,only:init_summa_HDS                                    ! initialize HDS variables for the first time step
  ! global data
  USE globalData,only:gru_struc                                  ! gru-hru mapping structures
  USE globalData,only:model_decisions                            ! model decision structure

--- a/build/source/driver/summa_restart.f90
+++ b/build/source/driver/summa_restart.f90
@@ -68,7 +68,8 @@ contains
  ! model decisions
  USE mDecisions_module,only:&                                ! look-up values for the choice of method for the spatial representation of groundwater
   localColumn, & ! separate groundwater representation in each local soil column
-  singleBasin    ! single groundwater store over the entire basin
+  singleBasin, & ! single groundwater store over the entire basin
+  HDSmodel       ! Hysteretic Depressional Storage model implementation for prairie potholes
  USE HDS,only:init_summa_HDS
  ! ---------------------------------------------------------------------------------------
  ! * variables
@@ -232,16 +233,17 @@ contains
   ! *****************************************************************************
   ! *** initialize HDS variables at the GRU level
   ! *****************************************************************************
-  call init_summa_HDS(bvarStruct%gru(iGRU)%var(iLookBVAR%pondVolFrac)%dat(1)      , &
-                      bparStruct%gru(iGRU)%var(iLookBPAR%depressionDepth)         , &
-                      bparStruct%gru(iGRU)%var(iLookBPAR%depressionAreaFrac)      , &
-                      bvarStruct%gru(iGRU)%var(iLookBVAR%basin__totalArea)%dat(1) , &
-                      bparStruct%gru(iGRU)%var(iLookBPAR%depression_p)            , &
-                      bvarStruct%gru(iGRU)%var(iLookBVAR%pondVol)%dat(1)          , &
-                      bvarStruct%gru(iGRU)%var(iLookBVAR%pondArea)%dat(1)         , &
-                      bvarStruct%gru(iGRU)%var(iLookBVAR%conAreaFrac)%dat(1)      , & 
-                      bvarStruct%gru(iGRU)%var(iLookBVAR%vMin)%dat(1))
-
+  if(model_decisions(iLookDECISIONS%prPotholes)%iDecision == HDSmodel)then
+   call init_summa_HDS(bvarStruct%gru(iGRU)%var(iLookBVAR%pondVolFrac)%dat(1)      , &
+                       bparStruct%gru(iGRU)%var(iLookBPAR%depressionDepth)         , &
+                       bparStruct%gru(iGRU)%var(iLookBPAR%depressionAreaFrac)      , &
+                       bvarStruct%gru(iGRU)%var(iLookBVAR%basin__totalArea)%dat(1) , &
+                       bparStruct%gru(iGRU)%var(iLookBPAR%depression_p)            , &
+                       bvarStruct%gru(iGRU)%var(iLookBVAR%pondVol)%dat(1)          , &
+                       bvarStruct%gru(iGRU)%var(iLookBVAR%pondArea)%dat(1)         , &
+                       bvarStruct%gru(iGRU)%var(iLookBVAR%conAreaFrac)%dat(1)      , & 
+                       bvarStruct%gru(iGRU)%var(iLookBVAR%vMin)%dat(1))
+  endif
  end do  ! end looping through GRUs
 
  ! *****************************************************************************

--- a/build/source/driver/summa_restart.f90
+++ b/build/source/driver/summa_restart.f90
@@ -30,6 +30,7 @@ USE var_lookup,only:iLookPROG                               ! look-up values for
 USE var_lookup,only:iLookDIAG                               ! look-up values for local column model diagnostic variables
 USE var_lookup,only:iLookFLUX                               ! look-up values for local column model fluxes
 USE var_lookup,only:iLookBVAR                               ! look-up values for basin-average model variables
+USE var_lookup,only:iLookBPAR                               ! look-up values for basin-average model parameters used by HDS
 USE var_lookup,only:iLookDECISIONS                          ! look-up values for model decisions
 
 ! safety: set private unless specified otherwise
@@ -68,6 +69,7 @@ contains
  USE mDecisions_module,only:&                                ! look-up values for the choice of method for the spatial representation of groundwater
   localColumn, & ! separate groundwater representation in each local soil column
   singleBasin    ! single groundwater store over the entire basin
+ USE HDS,only:init_summa_HDS
  ! ---------------------------------------------------------------------------------------
  ! * variables
  ! ---------------------------------------------------------------------------------------
@@ -226,6 +228,19 @@ contains
   do iHRU=1,gru_struc(iGRU)%hruCount
    dt_init%gru(iGRU)%hru(iHRU) = progStruct%gru(iGRU)%hru(iHRU)%var(iLookPROG%dt_init)%dat(1) ! seconds
   end do
+
+  ! *****************************************************************************
+  ! *** initialize HDS variables at the GRU level
+  ! *****************************************************************************
+  call init_summa_HDS(bvarStruct%gru(iGRU)%var(iLookBVAR%pondVolFrac)%dat(1)      , &
+                      bparStruct%gru(iGRU)%var(iLookBPAR%depressionDepth)         , &
+                      bparStruct%gru(iGRU)%var(iLookBPAR%depressionAreaFrac)      , &
+                      bvarStruct%gru(iGRU)%var(iLookBVAR%basin__totalArea)%dat(1) , &
+                      bparStruct%gru(iGRU)%var(iLookBPAR%depression_p)            , &
+                      bvarStruct%gru(iGRU)%var(iLookBVAR%pondVol)%dat(1)          , &
+                      bvarStruct%gru(iGRU)%var(iLookBVAR%pondArea)%dat(1)         , &
+                      bvarStruct%gru(iGRU)%var(iLookBVAR%conAreaFrac)%dat(1)      , & 
+                      bvarStruct%gru(iGRU)%var(iLookBVAR%vMin)%dat(1))
 
  end do  ! end looping through GRUs
 

--- a/build/source/driver/summa_restart.f90
+++ b/build/source/driver/summa_restart.f90
@@ -70,7 +70,7 @@ contains
   localColumn, & ! separate groundwater representation in each local soil column
   singleBasin, & ! single groundwater store over the entire basin
   HDSmodel       ! Hysteretic Depressional Storage model implementation for prairie potholes
- USE HDS,only:init_summa_HDS
+ USE HDS,only:init_summa_HDS                                 ! initialize HDS variables at the GRU level
  ! ---------------------------------------------------------------------------------------
  ! * variables
  ! ---------------------------------------------------------------------------------------

--- a/build/source/driver/summa_setup.f90
+++ b/build/source/driver/summa_setup.f90
@@ -29,7 +29,7 @@ USE globalData,only:realMissing      ! missing double precision number
 USE var_lookup,only:iLookATTR                               ! look-up values for local attributes
 USE var_lookup,only:iLookTYPE                               ! look-up values for classification of veg, soils etc.
 USE var_lookup,only:iLookPARAM                              ! look-up values for local column model parameters
-USE var_lookup,only:iLookID                              ! look-up values for local column model parameters
+USE var_lookup,only:iLookID                                 ! look-up values for local column model parameters
 USE var_lookup,only:iLookBVAR                               ! look-up values for basin-average model variables
 USE var_lookup,only:iLookDECISIONS                          ! look-up values for model decisions
 USE globalData,only:urbanVegCategory                        ! vegetation category for urban areas

--- a/build/source/dshare/get_ixname.f90
+++ b/build/source/dshare/get_ixname.f90
@@ -95,6 +95,7 @@ contains
   case('subRouting'      ); get_ixdecisions=iLookDECISIONS%subRouting  ! choice of method for sub-grid routing
   case('snowDenNew'      ); get_ixdecisions=iLookDECISIONS%snowDenNew  ! choice of method for new snow density
   case('snowUnload'      ); get_ixdecisions=iLookDECISIONS%snowUnload  ! choice of parameterization for snow unloading from canopy
+  case('prPotholes'      ); get_ixdecisions=iLookDECISIONS%prPotholes  ! choice of parameterization for prairie potholes
   ! get to here if cannot find the variable
   case default
    get_ixdecisions = integerMissing

--- a/build/source/dshare/get_ixname.f90
+++ b/build/source/dshare/get_ixname.f90
@@ -895,6 +895,13 @@ contains
   case('routingFractionFuture'         ); get_ixbvar = iLookBVAR%routingFractionFuture           ! fraction of runoff in future time steps (-)
   case('averageInstantRunoff'          ); get_ixbvar = iLookBVAR%averageInstantRunoff            ! instantaneous runoff (m s-1)
   case('averageRoutedRunoff'           ); get_ixbvar = iLookBVAR%averageRoutedRunoff             ! routed runoff (m s-1)
+  ! variables for pothole storage (HDS)
+  case('vMin'                          ); get_ixbvar = iLookBVAR%vMin                            ! volume of water in the meta depression at the start of a fill period (m3)
+  case('conAreaFrac'                   ); get_ixbvar = iLookBVAR%conAreaFrac                     ! fractional contributing area (-)
+  case('pondVolFrac'                   ); get_ixbvar = iLookBVAR%pondVolFrac                     ! fractional pond volume = pondVol/depressionVol (-)
+  case('pondVol'                       ); get_ixbvar = iLookBVAR%pondVol                         ! pond volume at the end of time step (m3)
+  case('pondArea'                      ); get_ixbvar = iLookBVAR%pondArea                        ! pond area at the end of the time step (m2)
+  case('pondOutflow'                   ); get_ixbvar = iLookBVAR%pondOutflow                     ! pond outflow (m3)
   ! get to here if cannot find the variable
   case default
    get_ixbvar = integerMissing

--- a/build/source/dshare/get_ixname.f90
+++ b/build/source/dshare/get_ixname.f90
@@ -861,6 +861,12 @@ contains
   ! sub-grid routing
   case('routingGammaShape'        ); get_ixbpar = iLookBPAR%routingGammaShape         ! shape parameter in Gamma distribution used for sub-grid routing (-)
   case('routingGammaScale'        ); get_ixbpar = iLookBPAR%routingGammaScale         ! scale parameter in Gamma distribution used for sub-grid routing (s)
+  ! parameters for HDS pothole storage
+  case('depressionDepth'        ); get_ixbpar = iLookBPAR%depressionDepth             ! average depth of depressional storage (depressionVol/depressionArea) (m)
+  case('depressionAreaFrac'     ); get_ixbpar = iLookBPAR%depressionAreaFrac          ! fractional depressional area (depressionArea/basinArea) (-)
+  case('depressionCatchAreaFrac'); get_ixbpar = iLookBPAR%depressionCatchAreaFrac     ! fractional area (of the landArea= basinArea - depressionArea) that drains to the depressions (-)
+  case('depression_p'           ); get_ixbpar = iLookBPAR%depression_p                ! shape of the slope profile (-)
+  case('depression_b'           ); get_ixbpar = iLookBPAR%depression_b                ! shape of contributing fraction curve (-)
   ! get to here if cannot find the variable
   case default
    get_ixbpar = integerMissing

--- a/build/source/dshare/popMetadat.f90
+++ b/build/source/dshare/popMetadat.f90
@@ -293,6 +293,15 @@ contains
  bpar_meta(iLookBPAR%basin__aquiferBaseflowExp)       = var_info('basin__aquiferBaseflowExp', 'baseflow exponent for the big bucket'                           , '-'    , get_ixVarType('scalarv'), iMissVec, iMissVec, .false.)
  bpar_meta(iLookBPAR%routingGammaShape)               = var_info('routingGammaShape'        , 'shape parameter in Gamma distribution used for sub-grid routing', '-'    , get_ixVarType('scalarv'), iMissVec, iMissVec, .false.)
  bpar_meta(iLookBPAR%routingGammaScale)               = var_info('routingGammaScale'        , 'scale parameter in Gamma distribution used for sub-grid routing', 's'    , get_ixVarType('scalarv'), iMissVec, iMissVec, .false.)
+ 
+ ! -----
+ ! * HDS pothole storage parameters...
+ ! -----------------------------------
+ bpar_meta(iLookBPAR%depressionDepth)                 = var_info('depressionDepth'          , 'average depth of depressional storage (depressionVol/depressionArea)'                       , 'm'    , get_ixVarType('scalarv'), iMissVec, iMissVec, .false.)
+ bpar_meta(iLookBPAR%depressionAreaFrac)              = var_info('depressionAreaFrac'       , 'fractional depressional area (depressionArea/basinArea)'                                    , '-'    , get_ixVarType('scalarv'), iMissVec, iMissVec, .false.)
+ bpar_meta(iLookBPAR%depressionCatchAreaFrac)         = var_info('depressionCatchAreaFrac'  , 'fractional area of the landArea (basinArea - depressionArea) that drains to the depressions', '-'    , get_ixVarType('scalarv'), iMissVec, iMissVec, .false.)
+ bpar_meta(iLookBPAR%depression_p)                    = var_info('depression_p'             , 'shape of the slope profile'                                                                 , '-'    , get_ixVarType('scalarv'), iMissVec, iMissVec, .false.)
+ bpar_meta(iLookBPAR%depression_b)                    = var_info('depression_b'             , 'shape of contributing fraction curve'                                                       , '-'    , get_ixVarType('scalarv'), iMissVec, iMissVec, .false.)
 
  ! -----
  ! * local model prognostic (state) variables...

--- a/build/source/dshare/popMetadat.f90
+++ b/build/source/dshare/popMetadat.f90
@@ -596,6 +596,16 @@ contains
  bvar_meta(iLookBVAR%routingFractionFuture)   = var_info('routingFractionFuture'  , 'fraction of runoff in future time steps'                , '-'     , get_ixVarType('routing'), iMissVec, iMissVec, .false.)
  bvar_meta(iLookBVAR%averageInstantRunoff)    = var_info('averageInstantRunoff'   , 'instantaneous runoff'                                   , 'm s-1' , get_ixVarType('scalarv'), iMissVec, iMissVec, .false.)
  bvar_meta(iLookBVAR%averageRoutedRunoff)     = var_info('averageRoutedRunoff'    , 'routed runoff'                                          , 'm s-1' , get_ixVarType('scalarv'), iMissVec, iMissVec, .false.)
+ 
+ ! -----
+ ! * basin-wide HDS pothole storage fluxes/variables...
+ ! -----------------------------------------
+ bvar_meta(iLookBVAR%vMin)                    = var_info('vMin'        , 'volume of water in the meta depression at the start of a fill period'  , 'm3'    , get_ixVarType('scalarv'), iMissVec, iMissVec, .false.)
+ bvar_meta(iLookBVAR%conAreaFrac)             = var_info('conAreaFrac' , 'fractional contributing area'                                          , '-'     , get_ixVarType('scalarv'), iMissVec, iMissVec, .false.)   
+ bvar_meta(iLookBVAR%pondVolFrac)             = var_info('pondVolFrac' , 'fractional pond volume at the end of time step'                        , '-'     , get_ixVarType('scalarv'), iMissVec, iMissVec, .false.)   
+ bvar_meta(iLookBVAR%pondVol)                 = var_info('pondVol'     , 'pond volume at the end of time step'                                   , 'm3'    , get_ixVarType('scalarv'), iMissVec, iMissVec, .false.)   
+ bvar_meta(iLookBVAR%pondArea)                = var_info('pondArea'    , 'pond area at the end of the time step'                                 , 'm2'    , get_ixVarType('scalarv'), iMissVec, iMissVec, .false.)   
+ bvar_meta(iLookBVAR%pondOutflow)             = var_info('pondOutflow' , 'pond outflow'                                                          , 'm3'    , get_ixVarType('scalarv'), iMissVec, iMissVec, .false.)   
 
  ! -----
  ! * model indices...

--- a/build/source/dshare/var_lookup.f90
+++ b/build/source/dshare/var_lookup.f90
@@ -690,6 +690,12 @@ MODULE var_lookup
   ! within-grid routing
   integer(i4b)    :: routingGammaShape          = integerMissing ! shape parameter in Gamma distribution used for sub-grid routing (-)
   integer(i4b)    :: routingGammaScale          = integerMissing ! scale parameter in Gamma distribution used for sub-grid routing (s)
+  ! define paramters for HDS pothole storage
+  integer(i4b)    :: depressionDepth            = integerMissing ! average depth of depressional storage (depressionVol/depressionArea) (m)
+  integer(i4b)    :: depressionAreaFrac         = integerMissing ! fractional depressional area (depressionArea/basinArea) (-)
+  integer(i4b)    :: depressionCatchAreaFrac    = integerMissing ! fractional area (of the landArea = basinArea - depressionArea) that drains to the depressions (-)
+  integer(i4b)    :: depression_p               = integerMissing ! shape of the slope profile (-)
+  integer(i4b)    :: depression_b               = integerMissing ! shape of contributing fraction curve (-)
  endtype iLook_bpar
 
  ! ***********************************************************************************************************
@@ -845,8 +851,8 @@ MODULE var_lookup
                                                                          41, 42, 43, 44, 45, 46, 47, 48, 49, 50,&
                                                                          51, 52, 53, 54, 55, 56, 57, 58, 59, 60)
 
- ! named variables: basin-average parameters
- type(iLook_bpar),    public,parameter :: iLookBPAR     =ilook_bpar    (  1,  2,  3,  4,  5)
+ ! named variables: basin-average parameters (including HDS parameters)
+ type(iLook_bpar),    public,parameter :: iLookBPAR     =ilook_bpar    (  1,  2,  3,  4,  5, 6, 7, 8, 9, 10)
 
  ! named variables: basin-average variables (including HDS variables)
  type(iLook_bvar),    public,parameter :: iLookBVAR     =ilook_bvar    (  1,  2,  3,  4,  5,  6,  7,  8,  9, 10,&

--- a/build/source/dshare/var_lookup.f90
+++ b/build/source/dshare/var_lookup.f90
@@ -71,6 +71,7 @@ MODULE var_lookup
   integer(i4b)    :: spatial_gw = integerMissing     ! choice of method for spatial representation of groundwater
   integer(i4b)    :: subRouting = integerMissing     ! choice of method for sub-grid routing
   integer(i4b)    :: snowDenNew = integerMissing     ! choice of method for new snow density
+  integer(i4b)    :: prPotholes = integerMissing     ! choice of method for prairie potholes representation
  endtype iLook_decision
 
  ! ***********************************************************************************************************
@@ -777,7 +778,7 @@ MODULE var_lookup
  type(iLook_decision),public,parameter :: iLookDECISIONS=iLook_decision(  1,  2,  3,  4,  5,  6,  7,  8,  9, 10,&
                                                                          11, 12, 13, 14, 15, 16, 17, 18, 19, 20,&
                                                                          21, 22, 23, 24, 25, 26, 27, 28, 29, 30,&
-                                                                         31, 32, 33, 34, 35, 36, 37, 38)
+                                                                         31, 32, 33, 34, 35, 36, 37, 38, 39)
  ! named variables: model time
  type(iLook_time),    public,parameter :: iLookTIME     =iLook_time    (  1,  2,  3,  4,  5,  6,  7)
 

--- a/build/source/dshare/var_lookup.f90
+++ b/build/source/dshare/var_lookup.f90
@@ -712,6 +712,13 @@ MODULE var_lookup
   integer(i4b)    :: routingFractionFuture      = integerMissing ! fraction of runoff in future time steps (-)
   integer(i4b)    :: averageInstantRunoff       = integerMissing ! instantaneous runoff (m s-1)
   integer(i4b)    :: averageRoutedRunoff        = integerMissing ! routed runoff (m s-1)
+  ! define variables for pothole storage (HDS)
+  integer(i4b)    :: vMin                       = integerMissing ! volume of water in the meta depression at the start of a fill period (m3)
+  integer(i4b)    :: conAreaFrac                = integerMissing ! fractional contributing area (-)
+  integer(i4b)    :: pondVolFrac                = integerMissing ! fractional pond volume at the end of time step (-)
+  integer(i4b)    :: pondVol                    = integerMissing ! pond volume at the end of time step (m3)
+  integer(i4b)    :: pondArea                   = integerMissing ! pond area at the end of the time step (m2)
+  integer(i4b)    :: pondOutflow                = integerMissing ! pond outflow (m3)
  endtype iLook_bvar
 
  ! ***********************************************************************************************************
@@ -841,9 +848,9 @@ MODULE var_lookup
  ! named variables: basin-average parameters
  type(iLook_bpar),    public,parameter :: iLookBPAR     =ilook_bpar    (  1,  2,  3,  4,  5)
 
- ! named variables: basin-average variables
+ ! named variables: basin-average variables (including HDS variables)
  type(iLook_bvar),    public,parameter :: iLookBVAR     =ilook_bvar    (  1,  2,  3,  4,  5,  6,  7,  8,  9, 10,&
-                                                                         11, 12, 13)
+                                                                         11, 12, 13, 14, 15, 16, 17, 18, 19)
 
  ! named variables in varibale type structure
  type(iLook_varType), public,parameter :: iLookVarType  =ilook_varType (  1,  2,  3,  4,  5,  6,  7,  8,  9, 10,&

--- a/build/source/engine/HDS.f90
+++ b/build/source/engine/HDS.f90
@@ -1,0 +1,262 @@
+module HDS
+    USE type_HDS
+
+    contains
+
+    subroutine init_pond_Area_Volume(depArea, depVol, totEvap, volFrac, p, pondVol, pondArea)
+        ! used to initialize pond volume and area
+        ! initialize at capacity minus depth of evaporation
+        implicit none
+        !subroutine arguments
+        real(rkind),  intent(in)  :: depArea                    ! depression area [m2]
+        real(rkind),  intent(in)  :: depVol                     ! depression volume [m3]
+        real(rkind),  intent(in)  :: totEvap                    ! total evaporation [m] to be subtracted from the ponded water
+        real(rkind),  intent(in)  :: volFrac                    ! volume fraction [-]. Used to fill the depressions using percentage (i.e., 50% full)
+        real(rkind),  intent(in)  :: p                          ! shape of the slope profile [-]. Exponent for calculating the fractional wet area
+        real(rkind),  intent(out) :: pondVol, pondArea          ! pond volume [m3], pond area [m2]
+        ! local variables
+        real(rkind)               :: depHeight  ! depression height [m]
+        real(rkind)               :: pondHeight ! height of the water level in depression [m]
+
+        ! estimate the maximum depth of the depression
+        depHeight = depVol*(one + two/p)/depArea  ! depression height [m]
+
+        !subtract ET from ponded water if ET > 0
+        if(totEvap > zero) then
+
+            ! estimate the height of the water level after evaporation
+            pondHeight = max(depHeight - totEvap, zero)
+
+            ! get the volume of water in the depression
+            pondVol = depVol*((pondHeight/depHeight)**(one  + two/p))
+
+        else !use volume frac to get initial pondVol
+            pondVol = depVol*volFrac
+        end if
+
+        ! calculate pondArea
+        pondArea = depArea*((pondVol/depVol)**(two/(p + two)))
+
+    end subroutine init_pond_Area_Volume
+
+    !=============================================================
+    !=============================================================
+    subroutine runDepression(pondVol,                  &       ! input/output:  state variable = pond volume [m3]
+                             qSeas, pRate, etPond,     &       ! input:         forcing data = runoff, precipitation, ET [mm/day]
+                             depArea, depVol, upsArea, &       ! input:         spatial attributes = depression area [m2], depression volume [m3], upstream area [m2]
+                             p, tau,                   &       ! input:         model parameters = p [-] shape of the slope profile; tau [day-1] time constant linear reservoir
+                             b, vmin,                  &       ! input:         model parameters = b [-] shape of contributing fraction curve; vmin [m3] minimum volume
+                             dt,                       &       ! input:         model time step [days]
+                             Q_det_adj, Q_dix_adj,     &       ! output:        adjusted evapotranspiration & infiltration fluxes [L3 T-1] for mass balance closure (i.e., when losses > pondVol)
+                             fVol, fArea,              &       ! output:        fractional volume [-], fractional contributing area [-]
+                             pondArea, pondOutflow)            ! output:        pond area at the end of the time step [m2], pond outflow [m3]
+
+
+        ! Estimate the volumetric storage at the end of the time interval using the numerical solution
+        implicit none
+        ! subroutine arguments
+        real(rkind),  intent(inout) :: pondVol, vmin               ! state variable = pond volume [m3], vmin [m3] minimum volume
+        real(rkind),  intent(in)    :: qSeas, pRate, etPond        ! input:         forcing data = runoff, precipitation, ET [mm/day]
+        real(rkind),  intent(in)    :: depArea, depVol, upsArea    ! input:         spatial attributes = depression area [m2], depression volume [m3], upstream area [m2]
+        real(rkind),  intent(in)    :: p, tau                      ! input:         model parameters = p [-] shape of the slope profile; tau [day-1] time constant linear reservoir
+        real(rkind),  intent(in)    :: b                           ! input:         model parameters = b [-] shape of contributing fraction curve; vminold [m3] minimum volume
+        real(rkind),  intent(in)    :: dt                          ! input:         model time step [days]
+        real(rkind),  intent(out)   :: Q_det_adj, Q_dix_adj        ! output:        adjusted evapotranspiration & infiltration fluxes [L3 T-1] for mass balance closure (i.e., when losses > pondVol). Zero values mean no adjustment needed.
+        real(rkind),  intent(out)   :: fVol, fArea                 ! output:        fractional volume [-], fractional contributing area [-]
+        real(rkind),  intent(out)   :: pondArea, pondOutflow       ! output:        pond area at the end of the time step [m2]
+        ! local variables -- model decisions
+        integer(i4b), parameter     :: implicitEuler=1001          ! named variable for the implicit Euler solution
+        integer(i4b), parameter     :: shortSubsteps=1002          ! named variable for the short substeps solution
+        integer(i4b)                :: solution                    ! numerical solution method
+        ! local variables --- implicit Euler solution
+        integer(i4b)                :: iter                        ! iteration counter
+        integer(i4b) , parameter    :: nIter=100                   ! number of iterations (algorithm control parameter)
+        real(rkind)  , parameter    :: xConv=1.e-6_rkind           ! convergence criteria (algorithm control parameter)
+        real(rkind)                 :: xMin, xMax                  ! min and max storage
+        real(rkind)                 :: xRes                        ! residual
+        logical(lgt)                :: failure                     ! failure flag
+        ! local variables -- short substeps solution
+        integer(i4b) , parameter    :: nSub=100                    ! number of substeps (algorithm control parameter)
+        integer(i4b)                :: iSub                        ! counter for shortSubsteps solution
+        real(rkind)                 :: dtSub                       ! dt for shortSubsteps solution
+        ! local variables -- diagnostic variables (model physics)
+        real(rkind)                 ::  Q_di, Q_det, Q_dix, Q_do   ! fluxes [L3 T-1]: sum of water inputs to the pond, evapotranspiration, infiltration, pond outflow
+        real(rkind)                 ::  cFrac, g, dgdv             ! contributing fraction, net fluxes and derivative
+        real(rkind)                 ::  xVol                       ! pond volume at the end of the time step [m3]
+
+        ! define numerical solution
+        solution      = implicitEuler
+        !solution      = shortSubsteps
+
+        ! initialize pond volume
+        xVol = pondVol
+        ! initialize corrected evaporation and infiltration for mass balance closure
+        Q_det_adj = zero
+        Q_dix_adj = zero
+
+        ! ---------- option 1: implicit Euler ----------
+
+        ! check if implicit Euler is desired
+        if(solution == implicitEuler)then
+
+            ! initialize brackets
+            xMin = zero
+            xMax = depVol
+
+            ! iterate (can start with 1 because the index is not used)
+            do iter=1,nIter
+
+                ! compute fluxes and derivatives
+                call computFlux(iter, xVol, qSeas, pRate, etPond, depArea, depVol, upsArea, p, tau, b, vMin, Q_di, Q_det, Q_dix, Q_do, cFrac, g, dgdv)
+
+                ! compute residual
+                xRes = (pondVol + g*dt) - xVol
+
+                ! check convergence
+                if(iter > 1 .and. abs(xRes) < xConv)then
+                    failure=.false.
+                    exit
+                endif
+
+                ! update constraints
+                if(xRes > zero) xMin=xVol
+                if(xRes < zero) xMax=xVol
+
+                ! special case where xMax is too small
+                if(xRes > zero  .and. xVol > 0.99*xMax) xMax = min(xMax*10.0_rkind, depVol)
+
+                ! update state (pondVol)
+                xVol = xVol + xRes / (one  - dgdv*dt)
+
+                ! use bi-section if violated constraints
+                if(xVol < xMin .or. xVol > xMax) xVol=(xMin+xMax)/2.0_rkind
+
+                ! assign failure
+                failure = (iter == nIter)
+
+            enddo ! iterating
+
+        endif  ! if implicit Euler
+
+        ! ---------- option 2: short substeps ----------
+
+        ! check if short substeps are desired
+        if(solution == shortSubsteps .or. failure)then
+
+            ! define length of the substeps
+            dtSub = one  / real(nSub, kind(rkind))
+
+            ! loop through substeps
+            do iSub=1,nSub
+                call computFlux(iter, xVol, qSeas, pRate, etPond, depArea, depVol, upsArea, p, tau, b, vMin, Q_di, Q_det, Q_dix, Q_do, cFrac, g, dgdv)
+                xVol = xVol + g*dtSub
+                ! if xVol is -ve, the code produces NaNs
+                ! prevent -ve ponVol values to avoid nans
+                if(xVol < zero)then
+                    xVol = zero
+                    ! adjust evaporation and infiltration fluxes proprtionally (using weights) to close mass balance (i.e., losses = PondVol)
+                    Q_det_adj = pondVol * (Q_det/(Q_det+Q_dix))
+                    Q_dix_adj = pondVol * (Q_dix/(Q_det+Q_dix))
+                    !break the loop as there's no need to continue xvol<zero
+                    exit
+                end if
+            enddo  ! looping through substeps
+
+        endif  ! if short substeps
+
+        ! ---------------------------------------------------------------------------------
+        ! ---------------------------------------------------------------------------------
+        ! ---------- fill and spill process for the meta depression model -----------------
+        fArea = cFrac
+        ! ---------------------------------------------------------------------------------
+        
+        ! save variables
+        pondVol = xVol
+        ! compute fractional volume and fractional area
+        fVol  = pondVol/depVol
+        ! compute the pond area at the end of the time step
+        pondArea = depArea*((pondVol/depVol)**(two/(p + two)))
+        ! pond outflow [m3]
+        pondOutflow = Q_do
+    end subroutine runDepression
+
+    !=============================================================
+    !=============================================================
+    subroutine computFlux(iter, pondVol,             & ! input:  iteration index, state variable = pond volume [m3]
+                          qSeas, pRate, etPond,      & ! input:  forcing data = runoff, precipitation, ET [mm/day]
+                          depArea, depVol, upsArea,  & ! input:  spatial attributes = depression area [m2], depression volume [m3], upstream area [m2]
+                          p, tau,                    & ! input:  model parameters = p [-] shape of the slope profile; tau [day-1] time constant linear reservoir
+                          b, vmin,                   & ! input:  model parameters = b [-] shape of contributing fraction curve; vmin [m3] minimum volume
+                          Q_di, Q_det, Q_dix, Q_do,  & ! output: individual model fluxes
+                          cFrac, g, dgdv)              ! output: contributing fraction, net fluxes and derivative
+        implicit none
+        ! subroutine arguments
+        integer, intent(in)         :: iter                        ! iteration index
+        real(rkind),  intent(in)    :: pondVol                     ! state variable = pond volume [m3]
+        real(rkind),  intent(in)    :: qSeas, pRate, etPond        ! input:  forcing data = runoff, precipitation, ET [mm/day]
+        real(rkind),  intent(in)    :: depArea, depVol, upsArea    ! input:  spatial attributes = depression area [m2], depression volume [m3], upstream area [m2]
+        real(rkind),  intent(in)    :: p, tau                      ! input:  model parameters = p [-] shape of the slope profile; tau [day-1] time constant linear reservoir
+        real(rkind),  intent(in)    :: b                           ! input:  model parameters = b [-] shape of contributing fraction curve; vmin [m3] minimum volume
+        real(rkind),  intent(inout) :: vmin                        ! in/out: vmin [m3] minimum volume
+        real(rkind),  intent(out)   :: Q_di, Q_det, Q_dix, Q_do    ! output: individual model fluxes
+        real(rkind),  intent(out)   :: cFrac, g, dgdv              ! output: contributing fraction, net fluxes and derivative, pond area
+        ! local variables
+        real(rkind), parameter      ::  ms=0.0001_rkind            ! smoothing parameter (algorithm control)
+        real(rkind), parameter      ::  rCoef=zero                 ! runoff coefficient [-] !HDS_standalone 0.050_rkind
+        real(rkind)                 ::  pondArea                   ! calculated pond area
+        real(rkind)                 ::  pInput                     ! precipitation (or rain+melt) [m/day]
+        real(rkind)                 ::  qInput                     ! surface runoff [m/day]
+        real(rkind)                 ::  eLosses                    ! evaporation losses [m/day]
+        real(rkind)                 ::  vPrime                     ! smoothed pondVol value for Euler solution
+        real(rkind)                 ::  vTry                       ! adjusted pondVol for derivatives calculations
+        real(rkind)                 ::  dadv, dpdv, dfdv, didv     ! derivatives
+
+        ! compute the pond area
+        pondArea = depArea*((pondVol/depVol)**(two/(p + two)))
+
+        ! get the forcing
+        pInput  = pRate /rho_w  ! kg m-2 -> m s-1
+        qInput  = qSeas /rho_w  + rCoef*pRate/rho_w  ! surface runoff ! kg m-2 s-1 -> m s-1
+        eLosses = etPond/rho_w  ! evaporation losses kg m-2 s-1 -> m s-1
+
+        ! get volume fluxes from the host land model
+        ! sum of water input to the depression (eq 11)
+        Q_di  = upsArea*qInput + (depArea - pondArea)*qInput + pondArea*pInput
+
+        ! evapotranspiration losses (eq 12)
+        Q_det = pondArea*eLosses
+
+        ! compute infiltration from the bottom of the pond (eq 13)
+        Q_dix = tau*pondVol
+
+        ! update the minimum parameter (force hysteresis)
+        if(iter == 1) then
+            if(Q_di < Q_det+Q_dix) vmin = pondVol
+        endif
+
+        ! compute the outflow from the meta depression
+        ! smoothing pondVol calculation ! (eq 24)
+        vPrime = half*(vMin + pondVol + sqrt((pondVol-vMin)**two  + ms)) ! (eq 24)
+        vPrime = min(vPrime, depVol) !MIA -> limit vPrime to be <= depVol
+        ! calculate contributing fraction !(eq 25)
+        cFrac  = one  - ((depVol - vPrime)/(depVol - vMin))**b !(eq 25)
+        cFrac = max(cFrac, zero ) !prevent -ve values MIA
+        ! calculate outlfow (eq 16)
+        Q_do   = cFrac*Q_di
+
+        ! compute the net flux (eq 10)
+        g = Q_di - Q_det - Q_dix - Q_do
+
+        ! compute derivate in pond area w.r.t. pond volume
+        vTry = max(verySmall, pondVol)  ! avoid divide by zero
+        dadv = ((two *depArea)/((p + two )*depVol)) * ((vTry/depVol)**(-p/(p + two )))
+
+        ! compute derivatives in volume fluxes w.r.t. pond volume (meta depression)
+        dpdv = half*((pondVol-vMin)/sqrt((pondVol-vMin)**two  + ms) + one )  ! max smoother
+        dfdv = dpdv*(b*(depVol - pondVol)**(b - one ))/((depVol - vMin)**b)  ! contributing fraction (note chain rule)
+        didv = dadv*(pInput - qInput)
+        dgdv = didv*(one  - cFrac) - dfdv*Q_di - dadv*eLosses - tau
+
+    end subroutine computFlux
+
+end module HDS

--- a/build/source/engine/HDS.f90
+++ b/build/source/engine/HDS.f90
@@ -1,6 +1,7 @@
 module HDS
     USE nrtype
-    ! USE globalData
+    ! physical constants
+    USE multiconst,only:iden_water ! intrinsic density of water    (kg m-3)
     
     contains
     subroutine init_summa_HDS(pondVolFrac, depressionDepth, depressionAreaFrac, totalArea, p, pondVol, pondArea, conArea, vMin)
@@ -251,9 +252,9 @@ module HDS
         pondArea = depArea*((pondVol/depVol)**(two/(p + two)))
 
         ! get the forcing
-        pInput  = pRate /rho_w  ! kg m-2 -> m s-1
-        qInput  = qSeas /rho_w  + rCoef*pRate/rho_w  ! surface runoff ! kg m-2 s-1 -> m s-1
-        eLosses = etPond/rho_w  ! evaporation losses kg m-2 s-1 -> m s-1
+        pInput  = pRate /iden_water  ! kg m-2 -> m s-1
+        qInput  = qSeas /iden_water  + rCoef*pRate/iden_water  ! surface runoff ! kg m-2 s-1 -> m s-1
+        eLosses = etPond/iden_water  ! evaporation losses kg m-2 s-1 -> m s-1
 
         ! get volume fluxes from the host land model
         ! sum of water input to the depression (eq 11)

--- a/build/source/engine/mDecisions.f90
+++ b/build/source/engine/mDecisions.f90
@@ -146,6 +146,9 @@ integer(i4b),parameter,public :: pahaut_76            = 314    ! Pahaut 1976, wi
 ! look-up values for the choice of snow unloading from the canopy
 integer(i4b),parameter,public :: meltDripUnload       = 321    ! Hedstrom and Pomeroy (1998), Storck et al 2002 (snowUnloadingCoeff & ratioDrip2Unloading)
 integer(i4b),parameter,public :: windUnload           = 322    ! Roesch et al 2001, formulate unloading based on wind and temperature
+! look-up values for the choice of prairie pothole parameterization
+integer(i4b),parameter,public :: noPotholes           = 331    ! no explicit pothole parameterization
+integer(i4b),parameter,public :: HDSmodel             = 332    ! Hysteretic Depressional Storage model implementation
 ! -----------------------------------------------------------------------------------------------------------
 
 contains
@@ -623,9 +626,18 @@ contains
  ! choice of snow unloading from canopy
  select case(trim(model_decisions(iLookDECISIONS%snowUnload)%cDecision))
   case('meltDripUnload','notPopulatedYet'); model_decisions(iLookDECISIONS%snowUnload)%iDecision = meltDripUnload  ! Hedstrom and Pomeroy (1998), Storck et al 2002 (snowUnloadingCoeff & ratioDrip2Unloading)
-  case('windUnload');                       model_decisions(iLookDECISIONS%snowUnload)%iDecision = windUnload          ! Roesch et al 2001, formulate unloading based on wind and temperature
+  case('windUnload');                       model_decisions(iLookDECISIONS%snowUnload)%iDecision = windUnload      ! Roesch et al 2001, formulate unloading based on wind and temperature
   case default
    err=10; message=trim(message)//"unknown option for snow unloading [option="//trim(model_decisions(iLookDECISIONS%snowUnload)%cDecision)//"]"; return
+ end select
+
+ ! choice of prairie potholes
+ ! NOTE: use noPotholes as the default, where prairie pothole method is undefined (not populated yet)
+ select case(trim(model_decisions(iLookDECISIONS%prPotholes)%cDecision))
+  case('noPotholes','notPopulatedYet');   model_decisions(iLookDECISIONS%prPotholes)%iDecision = noPotholes        ! No representation of prairie potholes
+  case('HDSmodel');                       model_decisions(iLookDECISIONS%prPotholes)%iDecision = HDSmodel          ! Hysteretic Depressional Storage model implementation
+  case default
+   err=10; message=trim(message)//"unknown option for prairie potholes [option="//trim(model_decisions(iLookDECISIONS%prPotholes)%cDecision)//"]"; return
  end select
 
 

--- a/build/source/engine/nrtype.f90
+++ b/build/source/engine/nrtype.f90
@@ -26,4 +26,13 @@ MODULE nrtype
  real(rkind),     parameter :: nr_quadMissing=-9999._qp   ! missing quadruple precision number
  real(rkind),     parameter :: nr_realMissing=-9999._rkind   ! missing double precision number
  integer(i4b), parameter :: nr_integerMissing=-9999    ! missing integer
+ ! data types for HDS pothole storage
+ ! useful shortcuts
+ real(rkind),  parameter  :: zero      = 0.0_rkind
+ real(rkind),  parameter  :: half      = 0.5_rkind
+ real(rkind),  parameter  :: one       = 1.0_rkind
+ real(rkind),  parameter  :: two       = 2.0_rkind
+ ! real(rkind),  parameter  :: verySmall = 1.0e-12_rkind
+ ! physical constants
+ real(rkind),  parameter  :: rho_w     = 1000._rkind  ! density of water (kg m-3)
 END MODULE nrtype

--- a/build/source/engine/nrtype.f90
+++ b/build/source/engine/nrtype.f90
@@ -32,7 +32,4 @@ MODULE nrtype
  real(rkind),  parameter  :: half      = 0.5_rkind
  real(rkind),  parameter  :: one       = 1.0_rkind
  real(rkind),  parameter  :: two       = 2.0_rkind
- ! real(rkind),  parameter  :: verySmall = 1.0e-12_rkind
- ! physical constants
- real(rkind),  parameter  :: rho_w     = 1000._rkind  ! density of water (kg m-3)
 END MODULE nrtype

--- a/build/source/engine/run_oneGRU.f90
+++ b/build/source/engine/run_oneGRU.f90
@@ -57,7 +57,7 @@ USE globalData,only:model_decisions    ! model decision structure
 USE var_lookup,only:iLookDECISIONS     ! look-up values for model decisions
 
 ! global data
-USE globalData,only:data_step              ! time step of forcing data (s) - used by HDS to accumulate fluxes
+USE globalData,only:data_step              ! time step of forcing data (s) - used by HDS to accumulate fluxes at each time step (forcing data step)
 
 ! provide access to the named variables that describe model decisions
 USE mDecisions_module,only:&           ! look-up values for the choice of method for the spatial representation of groundwater
@@ -329,7 +329,7 @@ contains
   ! activate HDS for this GRU
   ! initialize pondOutflow
   pondOutflow = 0._rkind
-  ! calculate some spatial attributes (should be moved somewhere else)
+  ! calculate some spatial attributes (might be moved somewhere else)
   depressionArea = depressionAreaFrac * totalArea
   depressionVol = depressionDepth * depressionArea
   landArea = totalArea - depressionArea

--- a/build/source/engine/run_oneGRU.f90
+++ b/build/source/engine/run_oneGRU.f90
@@ -325,14 +325,14 @@ contains
  depressionVol = depressionDepth * depressionArea
  landArea = totalArea - depressionArea
  upslopeArea = max(landArea * depressionCatchAreaFrac, 0._rkind)
-!  write(*,*) data_step
+
  ! run the actual HDS depressional storage model (currently catchfrac is not accounted for)
  call runDepression(&
                     ! subroutine inputs and parameters
                     pondVol                                                                , &    ! input/output:  state variable = pond volume [m3]
                     basinTotalRunoff * 0.001 * data_step                                   , &    ! forcing data       = runoff                [m s-1] -> mm/timestep
-                    basinPrecip * 0.001 * data_step                                        , &    ! forcing data       = precipitation         [m s-1] -> mm/timestep
-                    basinPotentialEvap * 0.001 * data_step                                 , &    ! forcing data       = potential evaporation [m s-1] -> mm/timestep
+                    basinPrecip * data_step                                                , &    ! forcing data       = precipitation         [mm s-1] -> mm/timestep
+                    basinPotentialEvap * data_step                                         , &    ! forcing data       = potential evaporation [mm s-1] -> mm/timestep
                     depressionArea                                                         , &    ! spatial attributes = depression area       [m2]
                     depressionVol                                                          , &    ! spatial attributes = depression volume     [m3]
                     upslopeArea                                                            , &    ! spatial attributes = upstream area         [m2]

--- a/build/source/engine/run_oneGRU.f90
+++ b/build/source/engine/run_oneGRU.f90
@@ -318,17 +318,6 @@ contains
  ! ********** PRAIRIE POTHOLE IMPLEMENTATION (HDS)************************************************************************
  ! ***********************************************************************************************************************
 
- ! parameters: the reamining 
- !  Initialize states (currently implemented here, but will be moved to either summa_restart or summa_modelRun)
- call init_summa_HDS(pondVolFrac        , &
-                     depressionDepth    , &
-                     depressionAreaFrac , &
-                     totalArea          , &
-                     depression_p       , &
-                     pondVol            , &
-                     pondArea           , &
-                     conAreaFrac        , & 
-                     vMin)
  ! initialize pondOutflow
  pondOutflow = 0._rkind
  ! calculate some spatial attributes (should be moved somewhere else)

--- a/build/source/engine/run_oneGRU.f90
+++ b/build/source/engine/run_oneGRU.f90
@@ -345,25 +345,6 @@ contains
                     Q_det_adj, Q_dix_adj                                                   , &    ! adjusted evapotranspiration & infiltration fluxes [L3 T-1] for mass balance closure (i.e., when losses > pondVol)
                     pondVolFrac, conAreaFrac                                               , &    ! fractional volume [-], fractional contributing area [-]
                     pondArea, pondOutflow)                                                        ! pond area at the end of the time step [m2], pond outflow [m3]    
-!  depressionArea = depressionAreaFrac * totalArea
-!  depressionVol = depressionDepth * depressionArea
-!  pondVol = pondVolFrac * depressionVol
-!  landArea = totalArea - depressionArea(n)
-!  upslopeArea = max(landArea * depressionCatchAreaFrac, zero)
-!  precip = 0.0
-!  pot_evap = 0.0
-!  runoff_depth = basinTotalRunoff
-!  call runDepression(pondVol,                                             &    ! input/output:  state variable = pond volume [m3]
-!                     runoff_depth, precip, pot_evap,                         &    ! input:         forcing data = runoff, precipitation, ET [mm/day]
-!                     depressionArea(n), depressionVol(n), upslopeArea, &    ! input:         spatial attributes = depression area [m2], depression volume [m3], upstream area [m2]
-!                     p(n), tau,                                              &    ! input:         model parameters = p [-] shape of the slope profile; tau [day-1] time constant linear reservoir
-!                     b(n), vMin,                                          &    ! input:         model parameters = b [-] shape of contributing fraction curve; vmin [m3] minimum volume
-!                     dt,                                                     &    ! input:         model time step [days]
-!                     Q_det_adj, Q_dix_adj,                                   &    ! output:        adjusted evapotranspiration & infiltration fluxes [L3 T-1] for mass balance closure (i.e., when losses > pondVol)
-!                     pondVolFrac, conAreaFrac,                             &    ! output:        fractional volume [-], fractional contributing area [-]
-!                     pondArea, pondOutflow)                              ! output:        pond area at the end of the time step [m2], pond outflow [m3]    
-
-
   ! ***********************************************************************************************************************                                               
                                                 
  call qOverland(&

--- a/build/source/engine/run_oneGRU.f90
+++ b/build/source/engine/run_oneGRU.f90
@@ -104,7 +104,7 @@ contains
 
  ! model control
  type(gru2hru_map)   , intent(inout) :: gruInfo              ! HRU information for given GRU (# HRUs, #snow+soil layers)
- real(rkind)            , intent(inout) :: dt_init(:)           ! used to initialize the length of the sub-step for each HRU
+ real(rkind)            , intent(inout) :: dt_init(:)        ! used to initialize the length of the sub-step for each HRU
  integer(i4b)        , intent(inout) :: ixComputeVegFlux(:)  ! flag to indicate if we are computing fluxes over vegetation (false=no, true=yes)
  ! data structures (input)
  integer(i4b)        , intent(in)    :: timeVec(:)           ! integer vector      -- model time data
@@ -132,7 +132,7 @@ contains
  integer(i4b)                            :: nSnow                  ! number of snow layers
  integer(i4b)                            :: nSoil                  ! number of soil layers
  integer(i4b)                            :: nLayers                ! total number of layers
- real(rkind)                                :: fracHRU                ! fractional area of a given HRU (-)
+ real(rkind)                             :: fracHRU                ! fractional area of a given HRU (-)
  logical(lgt)                            :: computeVegFluxFlag     ! flag to indicate if we are computing fluxes over vegetation (.false. means veg is buried with snow)
 
  ! initialize error control
@@ -277,6 +277,24 @@ contains
   bvarData%var(iLookBVAR%basin__TotalRunoff)%dat(1) = bvarData%var(iLookBVAR%basin__SurfaceRunoff)%dat(1) + bvarData%var(iLookBVAR%basin__ColumnOutflow)%dat(1)/totalArea + bvarData%var(iLookBVAR%basin__SoilDrainage)%dat(1)
  endif
 
+ ! ***********************************************************************************************************************
+ ! ********** PRAIRIE POTHOLE IMPLEMENTATION (HDS)************************************************************************
+ ! ***********************************************************************************************************************
+! variables: vMin, pondVol, pondArea, pondOutflow
+! parameters: the reamining 
+!  call runDepression(pondVol(n),                                             &    ! input/output:  state variable = pond volume [m3]
+!                     runoff_depth, precip, pot_evap,                         &    ! input:         forcing data = runoff, precipitation, ET [mm/day]
+!                     depressionArea(n), depressionVol(n), upslopeArea_small, &    ! input:         spatial attributes = depression area [m2], depression volume [m3], upstream area [m2]
+!                     p(n), tau,                                              &    ! input:         model parameters = p [-] shape of the slope profile; tau [day-1] time constant linear reservoir
+!                     b(n), vMin(n),                                          &    ! input:         model parameters = b [-] shape of contributing fraction curve; vmin [m3] minimum volume
+!                     dt,                                                     &    ! input:         model time step [days]
+!                     Q_det_adj, Q_dix_adj,                                   &    ! output:        adjusted evapotranspiration & infiltration fluxes [L3 T-1] for mass balance closure (i.e., when losses > pondVol)
+!                     vol_frac_small, conAreaFrac(n),                             &    ! output:        fractional volume [-], fractional contributing area [-]
+!                     pondArea(n), smallpond_outflow)                              ! output:        pond area at the end of the time step [m2], pond outflow [m3]    
+
+
+                                                
+                                                
  call qOverland(&
                 ! input
                 model_decisions(iLookDECISIONS%subRouting)%iDecision,          &  ! intent(in): index for routing method

--- a/build/source/netcdf/modelwrite.f90
+++ b/build/source/netcdf/modelwrite.f90
@@ -540,7 +540,7 @@ contains
 
  ! size of prognostic variable vector
  nProgVars = size(prog_meta)
- allocate(ncVarID(nProgVars+1))     ! include 1 additional basin variable in ID array (possibly more later)
+ allocate(ncVarID(nProgVars+5))     ! include 5 additional basin variable in ID array (routing + HDS variables)
 
  ! maximum number of soil layers
  maxSoil = gru_struc(1)%hruInfo(1)%nSoil
@@ -603,6 +603,23 @@ contains
  err = nf90_def_var(ncid, trim(bvar_meta(iLookBVAR%routingRunoffFuture)%varName), nf90_double, (/gruDimID, tdhDimID /), ncVarID(nProgVars+1))
  err = nf90_put_att(ncid,ncVarID(nProgVars+1),'long_name',trim(bvar_meta(iLookBVAR%routingRunoffFuture)%vardesc));   call netcdf_err(err,message)
  err = nf90_put_att(ncid,ncVarID(nProgVars+1),'units'    ,trim(bvar_meta(iLookBVAR%routingRunoffFuture)%varunit));   call netcdf_err(err,message)
+
+ ! define selected basin variables (pothole storage - HDS) -> vMin
+ err = nf90_def_var(ncid, trim(bvar_meta(iLookBVAR%vMin)%varName), nf90_double, (/gruDimID/), ncVarID(nProgVars+2))
+ err = nf90_put_att(ncid,ncVarID(nProgVars+2),'long_name',trim(bvar_meta(iLookBVAR%vMin)%vardesc));   call netcdf_err(err,message)
+ err = nf90_put_att(ncid,ncVarID(nProgVars+2),'units'    ,trim(bvar_meta(iLookBVAR%vMin)%varunit));   call netcdf_err(err,message)
+ ! define selected basin variables (pothole storage - HDS) -> conAreaFrac
+ err = nf90_def_var(ncid, trim(bvar_meta(iLookBVAR%conAreaFrac)%varName), nf90_double, (/gruDimID/), ncVarID(nProgVars+3))
+ err = nf90_put_att(ncid,ncVarID(nProgVars+3),'long_name',trim(bvar_meta(iLookBVAR%conAreaFrac)%vardesc));   call netcdf_err(err,message)
+ err = nf90_put_att(ncid,ncVarID(nProgVars+3),'units'    ,trim(bvar_meta(iLookBVAR%conAreaFrac)%varunit));   call netcdf_err(err,message)
+ ! define selected basin variables (pothole storage - HDS) -> pondVol
+ err = nf90_def_var(ncid, trim(bvar_meta(iLookBVAR%pondVolFrac)%varName), nf90_double, (/gruDimID/), ncVarID(nProgVars+4))
+ err = nf90_put_att(ncid,ncVarID(nProgVars+4),'long_name',trim(bvar_meta(iLookBVAR%pondVolFrac)%vardesc));   call netcdf_err(err,message)
+ err = nf90_put_att(ncid,ncVarID(nProgVars+4),'units'    ,trim(bvar_meta(iLookBVAR%pondVolFrac)%varunit));   call netcdf_err(err,message)
+ ! define selected basin variables (pothole storage - HDS) -> pondArea
+ err = nf90_def_var(ncid, trim(bvar_meta(iLookBVAR%pondArea)%varName), nf90_double, (/gruDimID/), ncVarID(nProgVars+5))
+ err = nf90_put_att(ncid,ncVarID(nProgVars+5),'long_name',trim(bvar_meta(iLookBVAR%pondArea)%vardesc));   call netcdf_err(err,message)
+ err = nf90_put_att(ncid,ncVarID(nProgVars+5),'units'    ,trim(bvar_meta(iLookBVAR%pondArea)%varunit));   call netcdf_err(err,message)
 
  ! define index variables - snow
  err = nf90_def_var(ncid,trim(indx_meta(iLookIndex%nSnow)%varName),nf90_int,(/hruDimID/),ncSnowID); call netcdf_err(err,message)
@@ -681,6 +698,12 @@ contains
   ! write selected basin variables
   err=nf90_put_var(ncid,ncVarID(nProgVars+1),(/bvar_data%gru(iGRU)%var(iLookBVAR%routingRunoffFuture)%dat/),  start=(/iGRU/),count=(/1,nTimeDelay/))
   
+  ! write pothole storage variables -> HDS
+  err=nf90_put_var(ncid,ncVarID(nProgVars+2),(/bvar_data%gru(iGRU)%var(iLookBVAR%vMin)%dat/),  start=(/iGRU/),count=(/1/))
+  err=nf90_put_var(ncid,ncVarID(nProgVars+3),(/bvar_data%gru(iGRU)%var(iLookBVAR%conAreaFrac)%dat/),  start=(/iGRU/),count=(/1/))
+  err=nf90_put_var(ncid,ncVarID(nProgVars+4),(/bvar_data%gru(iGRU)%var(iLookBVAR%pondVol)%dat/),  start=(/iGRU/),count=(/1/))
+  err=nf90_put_var(ncid,ncVarID(nProgVars+5),(/bvar_data%gru(iGRU)%var(iLookBVAR%pondArea)%dat/),  start=(/iGRU/),count=(/1/))
+
  end do  ! iGRU loop
 
  ! close file

--- a/build/source/netcdf/read_icond.f90
+++ b/build/source/netcdf/read_icond.f90
@@ -158,7 +158,7 @@ contains
  USE globalData,only:prog_meta                          ! metadata for prognostic variables
  USE globalData,only:bvar_meta                          ! metadata for basin (GRU) variables
  USE globalData,only:gru_struc                          ! gru-hru mapping structures
- USE globalData,only:startGRU                          ! index of first gru for parallel runs
+ USE globalData,only:startGRU                           ! index of first gru for parallel runs
  USE globaldata,only:iname_soil,iname_snow              ! named variables to describe the type of layer
  USE netcdf_util_module,only:nc_file_open               ! open netcdf file
  USE netcdf_util_module,only:nc_file_close              ! close netcdf file
@@ -170,7 +170,12 @@ contains
  USE data_types,only:var_info                           ! metadata
  USE get_ixName_module,only:get_varTypeName             ! to access type strings for error messages
  USE updatState_module,only:updateSoil                  ! update soil states
-
+ ! provide access to model decisions
+ USE globalData,only:model_decisions    ! model decision structure
+ USE var_lookup,only:iLookDECISIONS     ! look-up values for model decisions
+ ! provide access to the named variables that describe model decisions
+ USE mDecisions_module,only:HDSmodel                              ! Hysteretic Depressional Storage model implementation for prairie potholes
+ 
  implicit none
 
  ! --------------------------------------------------------------------------------------------------------
@@ -396,44 +401,42 @@ contains
  !********************************
  ! get basin variables for HDS
  !********************************
- hdsInitIdx = (/iLookBVAR%pondVolFrac, iLookBVAR%vMin, iLookBVAR%conAreaFrac, iLookBVAR%pondArea/) ! HDS initial conditions
+ if(model_decisions(iLookDECISIONS%prPotholes)%iDecision == HDSmodel)then
+  hdsInitIdx = (/iLookBVAR%pondVolFrac, iLookBVAR%vMin, iLookBVAR%conAreaFrac, iLookBVAR%pondArea/) ! HDS initial conditions
 
-!  iVar = iLookBVAR%pondVolFrac  
- ! get number of GRUs in file
- err = nf90_inq_dimid(ncID,"gru",dimID)
- if(err==nf90_noerr)then ! proceed if gru dimension exists 
-  err = nf90_inquire_dimension(ncID,dimID,len=fileGRU); if(err/=nf90_noerr)then; message=trim(message)//'problem reading gru dimension/'//trim(nf90_strerror(err)); return; end if
+  ! get number of GRUs in file
+  err = nf90_inq_dimid(ncID,"gru",dimID)
+  if(err==nf90_noerr)then ! proceed if gru dimension exists 
+   err = nf90_inquire_dimension(ncID,dimID,len=fileGRU); if(err/=nf90_noerr)then; message=trim(message)//'problem reading gru dimension/'//trim(nf90_strerror(err)); return; end if
  
-  do i = 1,size(hdsInitIdx)
-   iVar = hdsInitIdx(i)
+   do i = 1,size(hdsInitIdx)
+    iVar = hdsInitIdx(i)
   
-   ! get gru-based variable id
-   err = nf90_inq_varid(ncID,trim(bvar_meta(iVar)%varName),ncVarID); call netcdf_err(err,message)
-   ! skip any other vairable if missing
-   if(err/=0)then; message=trim(message)//': problem with getting basin variable id, var='//trim(bvar_meta(iVar)%varName); cycle; endif ! cycle is used to skip to the next hdsInitIdx if not found
+    ! get gru-based variable id
+    err = nf90_inq_varid(ncID,trim(bvar_meta(iVar)%varName),ncVarID); call netcdf_err(err,message)
+    ! skip any other vairable if missing
+    if(err/=0)then; message=trim(message)//': problem with getting basin variable id, var='//trim(bvar_meta(iVar)%varName); cycle; endif ! cycle is used to skip to the next hdsInitIdx if not found
 
-   ! initialize the gru variable data
-   allocate(varData(fileGRU,1),stat=err)
-   if(err/=0)then; print*, 'err= ',err; message=trim(message)//'problem allocating GRU variable data'; return; endif
+    ! initialize the gru variable data
+    allocate(varData(fileGRU,1),stat=err)
+    if(err/=0)then; print*, 'err= ',err; message=trim(message)//'problem allocating GRU variable data'; return; endif
 
-   ! get data
-   err = nf90_get_var(ncID,ncVarID,varData); call netcdf_err(err,message)
-   if(err/=0)then; message=trim(message)//': problem getting the data'; return; endif
+    ! get data
+    err = nf90_get_var(ncID,ncVarID,varData); call netcdf_err(err,message)
+    if(err/=0)then; message=trim(message)//': problem getting the data'; return; endif
 
-   ! store data in basin var (bvar) structure
-   do iGRU = 1,nGRU
-    ! put the data into data structures
-    bvarData%gru(iGRU)%var(iVar)%dat = varData((iGRU+startGRU-1),1)
-    ! ! check whether the first values is set to nf90_fill_double
-    ! if(any(abs(bvarData%gru(iGRU)%var(iVar)%dat(1:nTDH) - nf90_fill_double) < epsilon(varData)))then; err=20; endif
-    ! if(err==20)then; message=trim(message)//"data set to the fill value (name='"//trim(bvar_meta(iVar)%varName)//"')"; return; endif
-   end do ! end iGRU loop
+    ! store data in basin var (bvar) structure
+    do iGRU = 1,nGRU
+     ! put the data into data structures
+     bvarData%gru(iGRU)%var(iVar)%dat = varData((iGRU+startGRU-1),1)
+    end do ! end iGRU loop
 
-   ! deallocate temporary data array for next variable
-   deallocate(varData, stat=err)
-   if(err/=0)then; message=trim(message)//'problem deallocating GRU variable data'; return; endif
-  end do ! loop for hdsInitIdx
-end if ! end of check that gru dimension exists
+    ! deallocate temporary data array for next variable
+    deallocate(varData, stat=err)
+    if(err/=0)then; message=trim(message)//'problem deallocating GRU variable data'; return; endif
+   end do ! loop for hdsInitIdx
+  end if ! end of check that gru dimension exists
+endif ! end for model decision HDS
  !********************************
  !********************************
  

--- a/build/source/netcdf/read_icond.f90
+++ b/build/source/netcdf/read_icond.f90
@@ -406,6 +406,8 @@ contains
 
   ! get number of GRUs in file
   err = nf90_inq_dimid(ncID,"gru",dimID)
+  if(err/=nf90_noerr)then; message=trim(message)//'must define at least the pondVolFrac initial condition for HDS/'//trim(nf90_strerror(err)); return; end if
+
   if(err==nf90_noerr)then ! proceed if gru dimension exists 
    err = nf90_inquire_dimension(ncID,dimID,len=fileGRU); if(err/=nf90_noerr)then; message=trim(message)//'problem reading gru dimension/'//trim(nf90_strerror(err)); return; end if
  

--- a/build/source/netcdf/read_icond.f90
+++ b/build/source/netcdf/read_icond.f90
@@ -190,7 +190,7 @@ contains
  integer(i4b)                           :: fileHRU      ! number of HRUs in file
  integer(i4b)                           :: fileGRU      ! number of GRUs in file
  integer(i4b)                           :: iVar, i      ! loop indices
- integer(i4b),dimension(1)              :: ndx          ! intermediate array of loop indices
+ integer(i4b),dimension(5)              :: ndx          ! intermediate array of loop indices
  integer(i4b)                           :: iGRU         ! loop index
  integer(i4b)                           :: iHRU         ! loop index
  integer(i4b)                           :: dimID        ! varible dimension ids
@@ -418,7 +418,7 @@ contains
    endif
 
    ! loop through specific basin variables (currently 1 but loop provided to enable inclusion of others)
-   ndx = (/iLookBVAR%routingRunoffFuture/)   ! array of desired variable indices
+   ndx = (/iLookBVAR%routingRunoffFuture, iLookBVAR%vMin,  iLookBVAR%conAreaFrac, iLookBVAR%pondVolFrac, iLookBVAR%pondArea/)   ! array of desired variable indices
    do i = 1,size(ndx)
     iVar = ndx(i)
 


### PR DESCRIPTION
This is the initial implementation of the Hysteretic Depressional Storage (HDS) algorithm for prairie potholes in the SUMMA model.

The model has been tested under different I/O configurations and works as expected on a hypothetical test case.

To activate the HDS model, the following has to be done:
1. a model decision must be defined to activate HDS as:

       prPotholes                      HDSmodel        ! (39) choice of prairie pothole representation
2. The following HDS parameters must be defined at the GRU (basin) level in the `zParamTrial.nc` file (if the parameters are spatially variable) or in the`BasinParamInfo.txt` if they are spatially constant.
![Screenshot 2024-06-04 at 11 42 49 AM](https://github.com/CH-Earth/summa/assets/44171919/e336fc2e-f740-4ab9-8503-dd41893ca139)

4. At least one initial condition needs to be defined `pondVolFrac` at the GRU level in the `summa_zInitialCond_HDS.nc`