### PR TITLE
Consistency change in power-profile conductivity, adding groundwater options.

### DIFF
--- a/build/source/driver/summa_bmi.f90
+++ b/build/source/driver/summa_bmi.f90
@@ -240,6 +240,10 @@ module summabmi
   integer, parameter :: output_item_count = 16
   character (len=BMI_MAX_VAR_NAME), target,dimension(input_item_count)  :: input_items
   character (len=BMI_MAX_VAR_NAME), target,dimension(output_item_count) :: output_items
+  ! Buffers behind summa_get_ptr_int/float.  The BMI contract is that the returned pointer
+  ! stays valid after the call, so these cannot be the callers' own automatic arrays.
+  real,    target, allocatable :: ptr_buffer(:)
+  integer, target              :: iptr_buffer
   ! ---------------------------------------------------------------------------------------
 
   contains
@@ -976,7 +980,7 @@ module summabmi
      integer ,target :: itarget_arr
      integer :: bmi_status
 
-     call get_basin_field(this, name, 1, target_arr, itarget_arr) ! See near bottom of file
+     call get_basin_field(this, name, target_arr, itarget_arr) ! See near bottom of file
      ! use the real or integer target
      if(name(1:5)=='model')then ! not currently used, left in for future integer type needs
        size = sizeof(itarget_arr) ! 'sizeof' in gcc & ifort
@@ -1031,7 +1035,7 @@ module summabmi
 
      select case(name)
      case default
-       call get_basin_field(this, name, 1, target_arr, itarget_arr) ! See near bottom of file
+       call get_basin_field(this, name, target_arr, itarget_arr) ! See near bottom of file
        ! use the integer target
        dest = itarget_arr
        bmi_status = BMI_SUCCESS
@@ -1049,7 +1053,7 @@ module summabmi
 
      select case(name)
      case default
-       call get_basin_field(this, name, 1, target_arr, itarget_arr) ! See near bottom of file
+       call get_basin_field(this, name, target_arr, itarget_arr) ! See near bottom of file
        ! use the real target
        dest = target_arr
        bmi_status = BMI_SUCCESS
@@ -1075,18 +1079,16 @@ module summabmi
      class (summa_bmi), intent(in) :: this
      character (len=*), intent(in) :: name
      integer, pointer, intent(inout) :: dest_ptr(:)
-     integer :: bmi_status, n_elements
-     real, target    :: target_arr(sum(gru_struc(:)%hruCount))
-     integer ,target :: itarget_arr
+     integer :: bmi_status
+     real    :: target_arr(sum(gru_struc(:)%hruCount))
      type (c_ptr) :: src
 
      select case(name)
      case default
-       call get_basin_field(this, name, 1, target_arr, itarget_arr) ! See near bottom of file
-       ! use the integer target
-       src = c_loc(itarget_arr)
-       n_elements = sum(gru_struc(:)%hruCount)
-       call c_f_pointer(src, dest_ptr, [n_elements])
+       call get_basin_field(this, name, target_arr, iptr_buffer) ! See near bottom of file
+       ! use the integer target, which is a scalar (the 'model*' fields are not per-HRU)
+       src = c_loc(iptr_buffer)
+       call c_f_pointer(src, dest_ptr, [1])
        bmi_status = BMI_SUCCESS
      end select
    end function summa_get_ptr_int
@@ -1097,16 +1099,16 @@ module summabmi
      character (len=*), intent(in) :: name
      real, pointer, intent(inout) :: dest_ptr(:)
      integer :: bmi_status, n_elements
-     real, target    :: target_arr(sum(gru_struc(:)%hruCount))
-     integer ,target :: itarget_arr
+     integer :: itarget_arr
      type (c_ptr) :: src
 
      select case(name)
      case default
-       call get_basin_field(this, name, 1, target_arr, itarget_arr) ! See near bottom of file
-       ! use the real target
-       src = c_loc(target_arr(1))
        n_elements = sum(gru_struc(:)%hruCount)
+       if (.not. allocated(ptr_buffer)) allocate(ptr_buffer(n_elements))
+       call get_basin_field(this, name, ptr_buffer, itarget_arr) ! See near bottom of file
+       ! use the real target
+       src = c_loc(ptr_buffer(1))
        call c_f_pointer(src, dest_ptr, [n_elements])
        bmi_status = BMI_SUCCESS
      end select
@@ -1140,10 +1142,10 @@ module summabmi
 
      select case(name)
      case default
-       call get_basin_field(this, name, 1, target_arr, itarget_arr) ! See near bottom of file
-       ! use the integer target
+       call get_basin_field(this, name, target_arr, itarget_arr) ! See near bottom of file
+       ! use the integer target, which is a scalar (the 'model*' fields are not per-HRU)
        src = c_loc(itarget_arr)
-       call c_f_pointer(src, src_flattened, [n_elements])
+       call c_f_pointer(src, src_flattened, [1])
        n_elements = size(inds)
        do i = 1, n_elements
           dest(i) = src_flattened(inds(i))
@@ -1166,10 +1168,10 @@ module summabmi
 
      select case(name)
      case default
-       call get_basin_field(this, name, 1, target_arr, itarget_arr) ! See near bottom of file
+       call get_basin_field(this, name, target_arr, itarget_arr) ! See near bottom of file
        ! use the real target
        src = c_loc(target_arr(1))
-       call c_f_pointer(src, src_flattened, [n_elements])
+       call c_f_pointer(src, src_flattened, [size(target_arr)])
        n_elements = size(inds)
        do i = 1, n_elements
           dest(i) = src_flattened(inds(i))
@@ -1375,11 +1377,13 @@ module summabmi
      end associate summaVars
    end subroutine assign_basin_field
 
-   ! non-BMI helper function to get fields, only get first do_nHRU of them
-   subroutine get_basin_field(this, name, do_nHRU, target_arr, itarget_arr)
+   ! non-BMI helper function to get fields, for every HRU in the run.
+   ! NOTE: this used to take a do_nHRU argument and fill only the first do_nHRU entries,
+   !       leaving the rest at -999.  Every caller but the itemsize probe wants them all,
+   !       and all were passing 1, so callers were handed one value followed by -999s.
+   subroutine get_basin_field(this, name, target_arr, itarget_arr)
      implicit none
      class (summa_bmi), intent(in) :: this
-     integer, intent(in)  :: do_nHRU
      character (len=*), intent(in) :: name
      real, target, intent(out)    :: target_arr(sum(gru_struc(:)%hruCount))
      integer, target, intent(out) :: itarget_arr
@@ -1406,7 +1410,6 @@ module summabmi
         do iGRU = 1, this%model%summa1_struc(n)%nGRU
           do jHRU = 1, gru_struc(iGRU)%hruCount
             i = (iGRU-1) * gru_struc(iGRU)%hruCount + jHRU
-            if (i > do_nHRU) return
             target_arr(i) = 0._rkind
             do iDOM = 1, gru_struc(iGRU)%hruInfo(jHRU)%domCount
               fracDOM = progStruct%gru(iGRU)%hru(jHRU)%dom(iDOM)%var(iLookPROG%DOMarea)%dat(1)/ bvarStruct%gru(iGRU)%var(iLookBVAR%basin__totalArea)%dat(1)

--- a/build/source/dshare/data_types.f90
+++ b/build/source/dshare/data_types.f90
@@ -832,6 +832,7 @@ MODULE data_types
    real(rkind) :: qSurfScale          ! scaling factor in the surface runoff parameterization (-)
    real(rkind) :: zScale_TOPMODEL     ! scaling factor used to describe decrease in hydraulic conductivity with depth (m)
    real(rkind) :: f_hydCond           ! decay rate of hydraulic conductivity with depth, exponential profile (m-1)
+   real(rkind) :: compactedDepth      ! depth where k_soil reaches the compacted value, power-law profile (m)
    real(rkind) :: rootingDepth        ! rooting depth (m)
    real(rkind) :: wettingFrontSuction ! Green-Ampt wetting front suction (m)
    real(rkind) :: soilIceScale        ! soil ice scaling factor in Gamma distribution used to define frozen area (m)
@@ -1992,6 +1993,7 @@ subroutine initialize_in_diagv_node(in_diagv_node,iSoil,in_soilLiqFlux,diag_data
    qSurfScale          => mpar_data%var(iLookPARAM%qSurfScale)%dat(1),         & ! scaling factor in the surface runoff parameterization (-)
    zScale_TOPMODEL     => mpar_data%var(iLookPARAM%zScale_TOPMODEL)%dat(1),    & ! TOPMODEL scaling factor (m)
    f_hydCond           => mpar_data%var(iLookPARAM%f_hydCond)%dat(1),          & ! decay rate of hydraulic conductivity with depth (m-1)
+   compactedDepth      => mpar_data%var(iLookPARAM%compactedDepth)%dat(1),     & ! depth where k_soil reaches the compacted value (m)
    rootingDepth        => mpar_data%var(iLookPARAM%rootingDepth)%dat(1),       & ! rooting depth (m)
    wettingFrontSuction => mpar_data%var(iLookPARAM%wettingFrontSuction)%dat(1),& ! Green-Ampt wetting front suction (m)
    soilIceScale        => mpar_data%var(iLookPARAM%soilIceScale)%dat(1),       & ! scaling factor for depth of soil ice, used to get frozen fraction (m)
@@ -2006,6 +2008,7 @@ subroutine initialize_in_diagv_node(in_diagv_node,iSoil,in_soilLiqFlux,diag_data
    in_surfaceFlux % qSurfScale          = qSurfScale          ! scaling factor in the surface runoff parameterization (-)
    in_surfaceFlux % zScale_TOPMODEL     = zScale_TOPMODEL     ! scaling factor used to describe decrease in hydraulic conductivity with depth (m)
    in_surfaceFlux % f_hydCond           = f_hydCond           ! decay rate of hydraulic conductivity with depth, exponential profile (m-1)
+   in_surfaceFlux % compactedDepth      = compactedDepth      ! depth where k_soil reaches the compacted value, power-law profile (m)
    in_surfaceFlux % rootingDepth        = rootingDepth        ! rooting depth (m)
    if(nGlce>0) in_surfaceFlux % rootingDepth = max(rootingDepth,iLayerHeight(nSoil)) ! make all glacier debris layers take infiltration
    in_surfaceFlux % wettingFrontSuction = wettingFrontSuction ! Green-Ampt wetting front suction (m)

--- a/build/source/engine/coupled_em.f90
+++ b/build/source/engine/coupled_em.f90
@@ -1293,7 +1293,7 @@ subroutine coupled_em(&
                 iLayer = jLayer + nSoil
                 frz_scale_use = snowfrz_scale*icefrz_mult
               end if
-              mLayerVolFracWat(iLayer) = mLayerVolFracLiq(iLayer) + mLayerVolFracIce(iLayer)*iden_ice/iden_water
+              mLayerVolFracWat(iLayer) = mLayerVolFracLiq(iLayer) + mLayerVolFracIce(iLayer)*(iden_ice/iden_water)
               ! recompute enthalpy of layers if changed water and ice content
               if(enthalpyStateVec .or. computeEnthalpy)then
                  call T2enthTemp_snLaGl(&
@@ -1475,7 +1475,7 @@ subroutine coupled_em(&
                                                               prog_data%var(iLookPROG%mLayerVolFracIce)%dat(1:nSnow)*iden_ice) &
                                                             * prog_data%var(iLookPROG%mLayerDepth)%dat(1:nSnow) )
       prog_data%var(iLookPROG%mLayerVolFracWat)%dat(1) = prog_data%var(iLookPROG%mLayerVolFracLiq)%dat(1) &
-                                                        + prog_data%var(iLookPROG%mLayerVolFracIce)%dat(1)*iden_ice/iden_water
+                                                        + prog_data%var(iLookPROG%mLayerVolFracIce)%dat(1)*(iden_ice/iden_water)
       if(enthalpyStateVec .or. computeEnthalpy)then ! compute enthalpy of the top snow layer
         call T2enthTemp_snLaGl(&
                        .false.,                                           & ! intent(in):  flag that no liquid water in layer

--- a/build/source/engine/coupled_em.f90
+++ b/build/source/engine/coupled_em.f90
@@ -1293,7 +1293,7 @@ subroutine coupled_em(&
                 iLayer = jLayer + nSoil
                 frz_scale_use = snowfrz_scale*icefrz_mult
               end if
-              mLayerVolFracWat(iLayer) = mLayerVolFracLiq(iLayer) + mLayerVolFracIce(iLayer)*(iden_ice/iden_water)
+              mLayerVolFracWat(iLayer) = mLayerVolFracLiq(iLayer) + mLayerVolFracIce(iLayer)*iden_ice/iden_water
               ! recompute enthalpy of layers if changed water and ice content
               if(enthalpyStateVec .or. computeEnthalpy)then
                  call T2enthTemp_snLaGl(&

--- a/build/source/engine/groundwatr.f90
+++ b/build/source/engine/groundwatr.f90
@@ -282,10 +282,6 @@ subroutine computBaseflow(&
   real(rkind)                        :: drainableWater        ! drainable water in each layer (m)
   real(rkind)                        :: tran0                 ! maximum transmissivity (m2 s-1)
   real(rkind)                        :: surfaceHydCond_use    ! macropore conductivity at the soil surface (m s-1)
-  real(rkind)                        :: refDepth              ! reference depth for the power-law profile scaling (m)
-  real(rkind)                        :: cDepth                ! compacted depth, limited to the soil column (m)
-  real(rkind)                        :: scaleFacC             ! power-law scale factor at the compacted depth (-)
-  real(rkind)                        :: wtDepth               ! depth to the water table (m)
   integer(i4b)                       :: ix_hc_profile         ! index for the choice of the hydraulic conductivity profile
   real(rkind),dimension(nSoil)       :: xTrans                ! dimensionless transmissivity profile, trTotal = tran0*xTrans (-)
   real(rkind),dimension(nSoil)       :: zActive               ! water table thickness associated with storage below and including the given layer (m)
@@ -319,7 +315,6 @@ subroutine computBaseflow(&
     ! input: baseflow parameters
     zScale_TOPMODEL         => mpar_data%var(iLookPARAM%zScale_TOPMODEL)%dat(1),         & ! intent(in):  [dp]    TOPMODEL exponent (-)
     f_hydCond               => mpar_data%var(iLookPARAM%f_hydCond)%dat(1),               & ! intent(in):  [dp]    decay rate of hydraulic conductivity with depth (m-1)
-    compactedDepth          => mpar_data%var(iLookPARAM%compactedDepth)%dat(1),          & ! intent(in):  [dp]    depth where k_soil reaches the compacted value (m)
     kAnisotropic            => mpar_data%var(iLookPARAM%kAnisotropic)%dat(1),            & ! intent(in):  [dp]    anisotropy factor for lateral hydraulic conductivity (-)
     fieldCapacity           => mpar_data%var(iLookPARAM%fieldCapacity)%dat(1),           & ! intent(in):  [dp]    field capacity (-)
     theta_sat               => mpar_data%var(iLookPARAM%theta_sat)%dat,                  & ! intent(in):  [dp(:)] soil porosity (-)
@@ -379,35 +374,19 @@ subroutine computBaseflow(&
         xTrans(1:nSoil) = exp(-f_hydCond*(soilDepth - zActive(1:nSoil))) - exp(-f_hydCond*soilDepth)
         dXdS(1:nSoil)   = soilDepth*f_hydCond*exp(-f_hydCond*(soilDepth - zActive(1:nSoil)))
 
-      ! power-law transmissivity, the vertical integral of the same floored profile satHydCond builds,
-      !  K(z) = K_0*(1 - min(z,zc)/R)**(zScale_TOPMODEL-1), for zc = compactedDepth and R = refDepth.
-      ! For saturated thickness s, water table depth d = D-s, and Kc the scale factor at zc, that integrates to
-      !  s <= D-zc:  T = K_0*Kc*s                                                  (water table below the scaling zone)
-      !  s >  D-zc:  T = K_0*Kc*(D-zc) + K_0*(R/n)*[(1-d/R)**n - (1-zc/R)**n]
-      ! NOTE: zc < R always, so 1-min(z,zc)/R is bounded away from zero and this never evaluates 0**(n-1). That is why
-      !       satHydCond floors the profile in the first place, so the floor has to be carried through here too
+      ! power-law transmissivity, the classical TOPMODEL-ish form (Ambroise et al. 1996), the integral of
+      !  K_0*(1-z/D)**(zScale_TOPMODEL-1) over the saturated thickness
+      ! NOTE: this deliberately does NOT inherit the compactedDepth floor that satHydCond applies to the conductivity.
+      !       With qTopmodl the soil column is a conceptual shallow aquifer and zScale_TOPMODEL is a recession-calibration
+      !       parameter, not a soil property, so the transmissivity keeps its calibrated form
       case(powerLaw_profile)
-        refDepth  = soilDepth
-        if (soilDepth < compactedDepth) refDepth = compactedDepth + 1._rkind ! as in satHydCond
-        cDepth    = min(compactedDepth, soilDepth)
-        scaleFacC = (1._rkind - cDepth/refDepth)**(zScale_TOPMODEL - 1._rkind)
-        tran0     = kAnisotropic_use*surfaceHydCond_use*soilDepth
-        do iLayer=1,nSoil
-          if (zActive(iLayer) <= soilDepth - cDepth) then ! water table at or below the compacted depth, uniform conductivity
-            xTrans(iLayer) = scaleFacC*zActive(iLayer)/soilDepth
-            dXdS(iLayer)   = scaleFacC
-          else                                            ! water table up inside the scaling zone
-            wtDepth        = soilDepth - zActive(iLayer)
-            xTrans(iLayer) = scaleFacC*(soilDepth - cDepth)/soilDepth                                    &
-                             + ( refDepth/(zScale_TOPMODEL*soilDepth) )                                  &
-                               *( (1._rkind - wtDepth/refDepth)**zScale_TOPMODEL                         &
-                                - (1._rkind -  cDepth/refDepth)**zScale_TOPMODEL )
-            dXdS(iLayer)   = (1._rkind - wtDepth/refDepth)**(zScale_TOPMODEL - 1._rkind)
-          end if
-        end do
+        tran0 = kAnisotropic_use*surfaceHydCond_use*soilDepth/zScale_TOPMODEL
+        xTrans(1:nSoil) = (zActive(1:nSoil)/soilDepth)**zScale_TOPMODEL
+        dXdS(1:nSoil)   = zScale_TOPMODEL*(zActive(1:nSoil)/soilDepth)**(zScale_TOPMODEL - 1._rkind)
 
       ! uniform conductivity with depth, so transmissivity is simply linear in the saturated thickness
-      ! NOTE: grouped here only for completeness, mDecisions does not allow constant with qbaseTopmodel
+      ! NOTE: unreachable, mDecisions does not allow constant with qbaseTopmodel, but kept correct rather than
+      !       lumped in with the power law
       case(constant)
         tran0 = kAnisotropic_use*surfaceHydCond_use*soilDepth
         xTrans(1:nSoil) = zActive(1:nSoil)/soilDepth

--- a/build/source/engine/groundwatr.f90
+++ b/build/source/engine/groundwatr.f90
@@ -376,9 +376,8 @@ subroutine computBaseflow(&
 
       ! power-law transmissivity, the classical TOPMODEL-ish form (Ambroise et al. 1996), the integral of
       !  K_0*(1-z/D)**(zScale_TOPMODEL-1) over the saturated thickness
-      ! NOTE: this deliberately does NOT inherit the compactedDepth floor that satHydCond applies to the conductivity.
-      !       With qTopmodl the soil column is a conceptual shallow aquifer and zScale_TOPMODEL is a recession-calibration
-      !       parameter, not a soil property, so the transmissivity keeps its calibrated form
+      ! NOTE: this is the exact integral of the profile satHydCond builds, which decays to zero at the base
+      !       of the soil; that zero is the Beven-Kirkby premise of the shallow aquifer, not an artifact
       case(powerLaw_profile)
         tran0 = kAnisotropic_use*surfaceHydCond_use*soilDepth/zScale_TOPMODEL
         xTrans(1:nSoil) = (zActive(1:nSoil)/soilDepth)**zScale_TOPMODEL

--- a/build/source/engine/groundwatr.f90
+++ b/build/source/engine/groundwatr.f90
@@ -282,6 +282,10 @@ subroutine computBaseflow(&
   real(rkind)                        :: drainableWater        ! drainable water in each layer (m)
   real(rkind)                        :: tran0                 ! maximum transmissivity (m2 s-1)
   real(rkind)                        :: surfaceHydCond_use    ! macropore conductivity at the soil surface (m s-1)
+  real(rkind)                        :: refDepth              ! reference depth for the power-law profile scaling (m)
+  real(rkind)                        :: cDepth                ! compacted depth, limited to the soil column (m)
+  real(rkind)                        :: scaleFacC             ! power-law scale factor at the compacted depth (-)
+  real(rkind)                        :: wtDepth               ! depth to the water table (m)
   integer(i4b)                       :: ix_hc_profile         ! index for the choice of the hydraulic conductivity profile
   real(rkind),dimension(nSoil)       :: xTrans                ! dimensionless transmissivity profile, trTotal = tran0*xTrans (-)
   real(rkind),dimension(nSoil)       :: zActive               ! water table thickness associated with storage below and including the given layer (m)
@@ -315,6 +319,7 @@ subroutine computBaseflow(&
     ! input: baseflow parameters
     zScale_TOPMODEL         => mpar_data%var(iLookPARAM%zScale_TOPMODEL)%dat(1),         & ! intent(in):  [dp]    TOPMODEL exponent (-)
     f_hydCond               => mpar_data%var(iLookPARAM%f_hydCond)%dat(1),               & ! intent(in):  [dp]    decay rate of hydraulic conductivity with depth (m-1)
+    compactedDepth          => mpar_data%var(iLookPARAM%compactedDepth)%dat(1),          & ! intent(in):  [dp]    depth where k_soil reaches the compacted value (m)
     kAnisotropic            => mpar_data%var(iLookPARAM%kAnisotropic)%dat(1),            & ! intent(in):  [dp]    anisotropy factor for lateral hydraulic conductivity (-)
     fieldCapacity           => mpar_data%var(iLookPARAM%fieldCapacity)%dat(1),           & ! intent(in):  [dp]    field capacity (-)
     theta_sat               => mpar_data%var(iLookPARAM%theta_sat)%dat,                  & ! intent(in):  [dp(:)] soil porosity (-)
@@ -374,12 +379,39 @@ subroutine computBaseflow(&
         xTrans(1:nSoil) = exp(-f_hydCond*(soilDepth - zActive(1:nSoil))) - exp(-f_hydCond*soilDepth)
         dXdS(1:nSoil)   = soilDepth*f_hydCond*exp(-f_hydCond*(soilDepth - zActive(1:nSoil)))
 
-      ! power-law transmissivity, the original TOPMODEL-ish form
-      ! NOTE: constant is grouped here only for completeness, mDecisions does not allow it with qbaseTopmodel
-      case(constant, powerLaw_profile)
-        tran0 = kAnisotropic_use*surfaceHydCond_use*soilDepth/zScale_TOPMODEL
-        xTrans(1:nSoil) = (zActive(1:nSoil)/soilDepth)**zScale_TOPMODEL
-        dXdS(1:nSoil)   = zScale_TOPMODEL*(zActive(1:nSoil)/soilDepth)**(zScale_TOPMODEL - 1._rkind)
+      ! power-law transmissivity, the vertical integral of the same floored profile satHydCond builds,
+      !  K(z) = K_0*(1 - min(z,zc)/R)**(zScale_TOPMODEL-1), for zc = compactedDepth and R = refDepth.
+      ! For saturated thickness s, water table depth d = D-s, and Kc the scale factor at zc, that integrates to
+      !  s <= D-zc:  T = K_0*Kc*s                                                  (water table below the scaling zone)
+      !  s >  D-zc:  T = K_0*Kc*(D-zc) + K_0*(R/n)*[(1-d/R)**n - (1-zc/R)**n]
+      ! NOTE: zc < R always, so 1-min(z,zc)/R is bounded away from zero and this never evaluates 0**(n-1). That is why
+      !       satHydCond floors the profile in the first place, so the floor has to be carried through here too
+      case(powerLaw_profile)
+        refDepth  = soilDepth
+        if (soilDepth < compactedDepth) refDepth = compactedDepth + 1._rkind ! as in satHydCond
+        cDepth    = min(compactedDepth, soilDepth)
+        scaleFacC = (1._rkind - cDepth/refDepth)**(zScale_TOPMODEL - 1._rkind)
+        tran0     = kAnisotropic_use*surfaceHydCond_use*soilDepth
+        do iLayer=1,nSoil
+          if (zActive(iLayer) <= soilDepth - cDepth) then ! water table at or below the compacted depth, uniform conductivity
+            xTrans(iLayer) = scaleFacC*zActive(iLayer)/soilDepth
+            dXdS(iLayer)   = scaleFacC
+          else                                            ! water table up inside the scaling zone
+            wtDepth        = soilDepth - zActive(iLayer)
+            xTrans(iLayer) = scaleFacC*(soilDepth - cDepth)/soilDepth                                    &
+                             + ( refDepth/(zScale_TOPMODEL*soilDepth) )                                  &
+                               *( (1._rkind - wtDepth/refDepth)**zScale_TOPMODEL                         &
+                                - (1._rkind -  cDepth/refDepth)**zScale_TOPMODEL )
+            dXdS(iLayer)   = (1._rkind - wtDepth/refDepth)**(zScale_TOPMODEL - 1._rkind)
+          end if
+        end do
+
+      ! uniform conductivity with depth, so transmissivity is simply linear in the saturated thickness
+      ! NOTE: grouped here only for completeness, mDecisions does not allow constant with qbaseTopmodel
+      case(constant)
+        tran0 = kAnisotropic_use*surfaceHydCond_use*soilDepth
+        xTrans(1:nSoil) = zActive(1:nSoil)/soilDepth
+        dXdS(1:nSoil)   = 1._rkind
 
       case default
         message=trim(message)//"unknown hydraulic conductivity profile for the baseflow transmissivity"

--- a/build/source/engine/heat_Cp_Cm.f90
+++ b/build/source/engine/heat_Cp_Cm.f90
@@ -396,7 +396,7 @@ subroutine heatCapacity(&
                                      iden_air   * Cp_air   * ( 1._rkind - (mLayerVolFracIce(iLayer) + mLayerVolFracLiq(iLayer)) ) ! air component
             ! derivatives
             fLiq = mLayerFracLiq(iLayer)
-            dVolHtCapBulk_dTheta(iLayer) = iden_water * ( -Cp_ice*( fLiq-1._rkind ) + Cp_water*fLiq ) + iden_air * ( ( fLiq-1._rkind )*iden_water/iden_ice - fLiq ) * Cp_air
+            dVolHtCapBulk_dTheta(iLayer) = iden_water * ( -Cp_ice*( fLiq-1._rkind ) + Cp_water*fLiq ) + iden_air * ( ( fLiq-1._rkind )*(iden_water/iden_ice) - fLiq ) * Cp_air
             if( mLayerTemp(iLayer) < Tfreeze)then
               dVolHtCapBulk_dTk(iLayer) = ( iden_water * (-Cp_ice + Cp_water) + iden_air * (iden_water/iden_ice - 1._rkind) * Cp_air ) * mLayerdTheta_dTk(iLayer)
             else
@@ -566,11 +566,11 @@ subroutine heatAdvectWat(&
                 dCm_dTk(iLayer) = 0._rkind
               else
                 integral = (1._rkind/frz_scale_use) * atan(frz_scale_use * diffT)
-                mLayerCm(iLayer) = (iden_water * Cp_ice - iden_air * Cp_air * iden_water/iden_ice) * ( diffT - integral ) &
+                mLayerCm(iLayer) = (iden_water * Cp_ice - iden_air * Cp_air * (iden_water/iden_ice)) * ( diffT - integral ) &
                                        + (iden_water * Cp_water - iden_air * Cp_air) * integral
                 ! derivatives
                 dfLiq_dT = dFracLiq_dTk(mLayerTemp(iLayer),frz_scale_use,iLayer>nLayers-noThetaChange)
-                dCm_dTk(iLayer) = (iden_water * Cp_ice - iden_air * Cp_air * iden_water/iden_ice) * ( 1._rkind -fLiq ) &
+                dCm_dTk(iLayer) = (iden_water * Cp_ice - iden_air * Cp_air * (iden_water/iden_ice)) * ( 1._rkind -fLiq ) &
                                  + (iden_water * Cp_water - iden_air * Cp_air) * fLiq
               endif
             end if

--- a/build/source/engine/mDecisions.f90
+++ b/build/source/engine/mDecisions.f90
@@ -767,17 +767,34 @@ subroutine mDecisions(err,message)
     end if
   end if
 
-  ! check that maximum infiltration rate assumption aligns with groundwater option
-  ! TOPMODEL baseflow assumes a reduction in hydraulic conductivity with depth, possibly to 0 at the bottom of the soil, and infiltration rate assumptions must match these conductivities
-  ! BigBucket means we have an aquifer below the soil column, for which Green-Ampt is the most basic assumption. TOPMODEL_GA is not appropriate for this but for backward compatability we throw a warning instead of a graceful exit
-  select case(model_decisions(iLookDECISIONS%groundwatr)%iDecision)
-    case(qbaseTopmodel)
-      if(model_decisions(iLookDECISIONS%infRateMax)%iDecision /= topModel_GA)then
-        message=trim(message)//'maximum infiltration rate method must be topmodel_GA when using qTopmodl for groundwatr, not '//trim(model_decisions(iLookDECISIONS%infRateMax)%cDecision)//' (set "infRateMax" to "topmodel_GA" in model decisions input file)'
+  ! check that the maximum infiltration rate assumption matches the hydraulic conductivity profile
+  ! NOTE: the two infiltration options differ in whether the conductivity varies with depth, which is an hc_profile property and
+  !       not a groundwatr one. GreenAmpt assumes homogeneous soil and uses the surface conductivity, topmodel_GA evaluates the
+  !       hc_profile conductivity at the wetting front, and noInfExc uses neither. The qTopmodl requirement follows from this,
+  !       since qTopmodl already requires a depth-varying profile.
+  select case(model_decisions(iLookDECISIONS%hc_profile)%iDecision)
+    case(powerLaw_profile, expLaw_profile)
+      if(model_decisions(iLookDECISIONS%infRateMax)%iDecision /= topModel_GA .and. &
+         model_decisions(iLookDECISIONS%infRateMax)%iDecision /= noInfiltrationExcess)then
+        message=trim(message)//'maximum infiltration rate method must be topmodel_GA (or noInfExc) with a depth-varying hydraulic &
+          &conductivity profile, not '//trim(model_decisions(iLookDECISIONS%infRateMax)%cDecision)//' (set "infRateMax" to &
+          &"topmodel_GA" in model decisions input file)'
         err=20; return
       end if
-    case(bigBucket)
+    case(constant)
       if(model_decisions(iLookDECISIONS%infRateMax)%iDecision == topModel_GA)then
+        write(*,*) 'DEPRECATION WARNING: infRateMax topmodel_GA evaluates the hydraulic conductivity at the wetting front, but hc_profile is constant so the column is homogeneous. Please use GreenAmpt instead (set "infRateMax" to "GreenAmpt" in model decisions input file)'
+      end if
+  end select
+
+  ! BigBucket means we have an aquifer below the soil column, for which Green-Ampt is the most basic assumption. TOPMODEL_GA is not appropriate for this but for backward compatability we throw a warning instead of a graceful exit
+  ! NOTE: only advise this for a constant conductivity profile. With a depth-varying profile the check above requires topmodel_GA,
+  !       so advising GreenAmpt here would contradict it, and escalating this to an error would leave that combination with no
+  !       legal infRateMax at all
+  select case(model_decisions(iLookDECISIONS%groundwatr)%iDecision)
+    case(bigBucket)
+      if(model_decisions(iLookDECISIONS%infRateMax)%iDecision == topModel_GA .and. &
+         model_decisions(iLookDECISIONS%hc_profile)%iDecision == constant)then
         write(*,*) 'DEPRECATION WARNING: Combining groundwater parametrization bigBucket with maximum infiltration rate method topModel_GA is not recommended. This was the default in SUMMA v3.x.x and below, but is not appropriate for this groundwater option. Please use Green-Ampt instead (set "infRateMax" to "GreenAmpt" in model decisions input file)'
         ! This preps us for when we want to remove this option in the future
         !message=trim(message)//'maximum infiltration rate method (infRateMax) cannot be topModel_GA when using BigBucket for groundwater, use GreenAmpt instead'

--- a/build/source/engine/mDecisions.f90
+++ b/build/source/engine/mDecisions.f90
@@ -506,6 +506,13 @@ subroutine mDecisions(err,message)
     case('constant'); model_decisions(iLookDECISIONS%hc_profile)%iDecision = constant            ! constant hydraulic conductivity with depth
     case('pow_prof'); model_decisions(iLookDECISIONS%hc_profile)%iDecision = powerLaw_profile    ! power-law profile
     case('exp_prof'); model_decisions(iLookDECISIONS%hc_profile)%iDecision = expLaw_profile      ! exponential profile
+      ! STUB: exp_prof models lateral flow over a finite impermeable base rather than a shallow aquifer, so it is not yet
+      !       selectable for ordinary runs. Glacier domains do not need it here, they override to expLaw_profile internally
+      !       in satHydCond, soilLiqFlux and computBaseflow. Enable this when the MODFLOW-coupled aquifer lands.
+      message=trim(message)//'the exponential hydraulic conductivity profile is not yet selectable ("hc_profile" = "exp_prof"): &
+        &it represents lateral flow over an impermeable base rather than a shallow groundwater aquifer, and is currently used &
+        &only internally for glacier debris domains'
+      err=20; return
     case default
       err=10; message=trim(message)//"unknown hydraulic conductivity profile [option="//trim(model_decisions(iLookDECISIONS%hc_profile)%cDecision)//"]"; return
   end select

--- a/build/source/engine/mDecisions.f90
+++ b/build/source/engine/mDecisions.f90
@@ -506,13 +506,6 @@ subroutine mDecisions(err,message)
     case('constant'); model_decisions(iLookDECISIONS%hc_profile)%iDecision = constant            ! constant hydraulic conductivity with depth
     case('pow_prof'); model_decisions(iLookDECISIONS%hc_profile)%iDecision = powerLaw_profile    ! power-law profile
     case('exp_prof'); model_decisions(iLookDECISIONS%hc_profile)%iDecision = expLaw_profile      ! exponential profile
-      ! STUB: exp_prof models lateral flow over a finite impermeable base rather than a shallow aquifer, so it is not yet
-      !       selectable for ordinary runs. Glacier domains do not need it here, they override to expLaw_profile internally
-      !       in satHydCond, soilLiqFlux and computBaseflow. Enable this when the MODFLOW-coupled aquifer lands.
-      message=trim(message)//'the exponential hydraulic conductivity profile is not yet selectable ("hc_profile" = "exp_prof"): &
-        &it represents lateral flow over an impermeable base rather than a shallow groundwater aquifer, and is currently used &
-        &only internally for glacier debris domains'
-      err=20; return
     case default
       err=10; message=trim(message)//"unknown hydraulic conductivity profile [option="//trim(model_decisions(iLookDECISIONS%hc_profile)%cDecision)//"]"; return
   end select
@@ -748,13 +741,21 @@ subroutine mDecisions(err,message)
       end if
   end select
 
-  ! check a depth-varying conductivity profile is selected when using topmodel baseflow option
-  ! NOTE: the baseflow transmissivity is the vertical integral of the conductivity profile, so both are supported
+  ! check the conductivity profile is compatible with the topmodel baseflow option
+  ! NOTE: elsewhere hc_profile only sets the vertical conductivity, since computBaseflow runs for qTopmodl (and glaciers) alone,
+  !       so exp_prof is unrestricted there. Only with qTopmodl does it change the transmissivity, to the finite impermeable base
+  !       form that has no aquifer beneath, which is the MODFLOW-coupled case and is not enabled yet. Glacier domains do not need
+  !       it selectable, they override to expLaw_profile internally in satHydCond, soilLiqFlux and computBaseflow.
   select case(model_decisions(iLookDECISIONS%groundwatr)%iDecision)
     case(qbaseTopmodel)
-      if(model_decisions(iLookDECISIONS%hc_profile)%iDecision /= powerLaw_profile .and. &
-         model_decisions(iLookDECISIONS%hc_profile)%iDecision /= expLaw_profile)then
-        message=trim(message)//'a power-law or exponential hydraulic conductivity profile must be selected when using topmodel baseflow option (set "hc_profile" to "pow_prof" or "exp_prof" in model decisions input file)'
+      if(model_decisions(iLookDECISIONS%hc_profile)%iDecision == expLaw_profile)then
+        message=trim(message)//'the exponential hydraulic conductivity profile is not yet selectable with the topmodel baseflow &
+          &option: it makes the transmissivity the finite impermeable base form, lateral flow with no shallow aquifer beneath, &
+          &which is reserved for the MODFLOW coupled aquifer (set "hc_profile" to "pow_prof" in model decisions input file)'
+        err=20; return
+      end if
+      if(model_decisions(iLookDECISIONS%hc_profile)%iDecision /= powerLaw_profile)then
+        message=trim(message)//'a power-law hydraulic conductivity profile must be selected when using topmodel baseflow option (set "hc_profile" to "pow_prof" in model decisions input file)'
         err=20; return
       end if
   end select

--- a/build/source/engine/mDecisions.f90
+++ b/build/source/engine/mDecisions.f90
@@ -760,6 +760,19 @@ subroutine mDecisions(err,message)
       end if
   end select
 
+  ! check the conductivity profile is compatible with the lower boundary condition
+  ! NOTE: the power-law conductivity reaches exactly zero at the base of the soil, so iLayerSatHydCond(nSoil)
+  !       is zero and the prescribed-head drainage flux, scalarDrainage = cflux + bottomSatHydCond, is
+  !       identically zero whatever head is prescribed. That is a silent no-op, so reject it rather than
+  !       flooring the profile: use exp_prof, which decays with depth but stays finite at the base.
+  if(model_decisions(iLookDECISIONS%bcLowrSoiH)%iDecision == prescribedHead .and. &
+     model_decisions(iLookDECISIONS%hc_profile)%iDecision == powerLaw_profile)then
+    message=trim(message)//'a power-law hydraulic conductivity profile cannot be used with a prescribed-head lower &
+      &boundary: the conductivity is zero at the base of the soil, so the prescribed head can drive no drainage &
+      &(set "hc_profile" to "exp_prof" or "constant" in model decisions input file)'
+    err=20; return
+  end if
+
   ! check bigBucket groundwater option is used when for spatial groundwater is singleBasin
   if(model_decisions(iLookDECISIONS%spatial_gw)%iDecision == singleBasin)then
     if(model_decisions(iLookDECISIONS%groundwatr)%iDecision /= bigBucket)then

--- a/build/source/engine/read_pinit.f90
+++ b/build/source/engine/read_pinit.f90
@@ -174,7 +174,9 @@ contains
   end if
   ! exponential hydraulic conductivity profile
   if (parFallback(iLookPARAM%f_hydCond)%default_val < 0.99_rkind*realMissing) then
-    parFallback(iLookPARAM%f_hydCond)%default_val = 3._rkind ! 1-5 m-1 for supraglacial debris and weathered shallow till
+    ! NOTE: a soil-column value, leaving ~5% of the surface conductivity at 4 m. Supraglacial debris is 1-5 m-1 over a 0.3-1 m
+    !       depth, so glacier runs should set f_hydCond explicitly rather than take this default
+    parFallback(iLookPARAM%f_hydCond)%default_val = 0.75_rkind
   end if
  else
   ! glacier parameters

--- a/build/source/engine/run_oneGRU.f90
+++ b/build/source/engine/run_oneGRU.f90
@@ -84,13 +84,18 @@ USE globalData,only:glacCln2           ! second horizontal domain type for glaci
 USE globalData,only:glacDbr            ! horizontal domain type for glacier debris areas
 USE globalData,only:wetland            ! horizontal domain type for wetland areas
 
-! provide access to the named variables that describe model decisions
-USE mDecisions_module,only:&           ! look-up values for the choice of method for the spatial representation of groundwater
- localColumn, &                        ! separate groundwater representation in each local soil column
- singleBasin, &                        ! single groundwater store over the entire basin
- bigBucket                             ! a big bucket (lumped aquifer model)
-! -----------------------------------------------------------------------------------------------------------------------------------
-implicit none
+! look-up values for the choice of groundwater parameterization
+USE mDecisions_module,only:       &
+ qbaseTopmodel,                   & ! TOPMODEL-ish baseflow parameterization
+ bigBucket,                       & ! a big bucket (lumped aquifer model)
+ noExplicit                         ! no explicit groundwater parameterization
+
+! look-up values for the choice of method for the spatial representation of groundwater
+USE mDecisions_module,only:       & 
+ localColumn,                     & ! separate groundwater representation in each local soil column
+ singleBasin                        ! single groundwater store over the entire basin
+
+ implicit none
 private
 public::run_oneGRU
 contains
@@ -160,6 +165,11 @@ subroutine run_oneGRU(&
   character(len=512)                  :: cmessage                       ! error message
   integer(i4b)                        :: iHRU                           ! HRU index
   integer(i4b)                        :: jHRU,kHRU                      ! index of the hydrologic response unit
+  integer(i4b)                        :: iSeq                           ! position in the cascade processing order
+  integer(i4b)                        :: nOrder                         ! number of HRUs placed in the processing order
+  integer(i4b), allocatable           :: downIdx(:)                     ! index of the downslope HRU (0 = GRU outlet)
+  integer(i4b), allocatable           :: inDegree(:)                    ! number of HRUs draining into a given HRU
+  integer(i4b), allocatable           :: hruOrder(:)                    ! HRU indices in cascade order, upslope before downslope
   integer(i4b)                        :: iDOM                           ! domain index
   real(rkind)                         :: fracDOM                        ! fractional area of a given HRU domain in GRU (-)
   integer(i4b)                        :: nglacDOM                       ! number of glacier domains in the GRU
@@ -283,8 +293,41 @@ subroutine run_oneGRU(&
              glac_tan_slope(nglacDOM),glac_aspect(nglacDOM),glac_contourLength(nglacDOM))
   endif
 
-  ! ********** RUN FOR ONE HRU ********************************************************************************************
+  ! ----- order the HRUs so that an HRU is run after everything that drains into it -----------------------------------------
+  allocate(downIdx(gruInfo%hruCount), inDegree(gruInfo%hruCount), hruOrder(gruInfo%hruCount), stat=err)
+  if(err/=0)then; message=trim(message)//'problem allocating cascade ordering arrays'; return; endif
+  downIdx(:) = 0; inDegree(:) = 0
   do iHRU=1,gruInfo%hruCount
+    dsHRU: do jHRU=1,gruInfo%hruCount
+      if(typeHRU%hru(iHRU)%var(iLookTYPE%downHRUindex) == idHRU%hru(jHRU)%var(iLookID%hruId))then
+        downIdx(iHRU) = jHRU                  ! first match wins, as before
+        inDegree(jHRU) = inDegree(jHRU) + 1
+        exit dsHRU
+      endif
+    enddo dsHRU
+  enddo
+  ! repeatedly take an HRU nothing drains into, then remove its own contribution
+  nOrder = 0
+  do iHRU=1,gruInfo%hruCount
+    if(inDegree(iHRU)==0)then; nOrder = nOrder + 1; hruOrder(nOrder) = iHRU; endif
+  enddo
+  iSeq = 0
+  do while(iSeq < nOrder)
+    iSeq = iSeq + 1
+    kHRU = downIdx(hruOrder(iSeq))
+    if(kHRU > 0)then
+      inDegree(kHRU) = inDegree(kHRU) - 1
+      if(inDegree(kHRU)==0)then; nOrder = nOrder + 1; hruOrder(nOrder) = kHRU; endif
+    endif
+  end do
+  if(nOrder /= gruInfo%hruCount)then
+    err=20; message=trim(message)//'the downHRUindex cascade network contains a loop, so the HRUs cannot be ordered upslope to &
+      &downslope (check downHRUindex in the attributes file)'; return
+  endif
+
+  ! ********** RUN FOR ONE HRU ********************************************************************************************
+  do iSeq=1,gruInfo%hruCount
+    iHRU = hruOrder(iSeq)
     
     ! skip HRUs with no area
     runHRU = .false.
@@ -326,18 +369,8 @@ subroutine run_oneGRU(&
     if(.not. computeVegFluxFlag) ixComputeVegFlux%hru(iHRU) = no
 
     ! ----- compute fluxes across HRUs --------------------------------------------------------------------------------------------------
-    ! identify lateral connectivity
-    ! (Note:  for efficiency, this could this be done as a setup task, not every timestep)
-    kHRU = 0
-    ! identify the downslope HRU
-    dsHRU: do jHRU=1,gruInfo%hruCount
-      if(typeHRU%hru(iHRU)%var(iLookTYPE%downHRUindex) == idHRU%hru(jHRU)%var(iLookID%hruId))then
-        if(kHRU==0)then  ! check there is a unique match
-          kHRU=jHRU
-          exit dsHRU
-        endif  ! (check there is a unique match)
-      endif  ! (if identified a downslope HRU)
-    enddo dsHRU
+    ! the downslope HRU, found once above with the cascade ordering
+    kHRU = downIdx(iHRU)
     
     do iDOM = 1, gruInfo%hruInfo(iHRU)%domCount
       if(progHRU%hru(iHRU)%dom(iDOM)%var(iLookPROG%DOMarea)%dat(1)==0._rkind) cycle ! skip domains with no area
@@ -671,6 +704,8 @@ subroutine run_oneGRU(&
 
   ! aggregate the elapsed time for the update area routines
    elapsedUpdateArea = elapsedUpdateArea + elapsedSec(startUpdateArea,endUpdateArea)
+
+  deallocate(downIdx,inDegree,hruOrder)
 
 end subroutine run_oneGRU
 

--- a/build/source/engine/soilLiqFlux.f90
+++ b/build/source/engine/soilLiqFlux.f90
@@ -786,7 +786,7 @@ subroutine surfaceFlux(io_soilLiqFlux,in_surfaceFlux,io_surfaceFlux,out_surfaceF
   real(rkind)                      :: hydCondWettingFront                 ! hydraulic conductivity at the wetting front (m s-1)
   real(rkind)                      :: dHydCondWF_dDepth                   ! derivative in hydraulic conductivity at the wetting front w.r.t. its depth (s-1)
   real(rkind)                      :: refDepth_use                        ! reference depth for the power-law profile scaling (m)
-  real(rkind)                      :: cDepth_use                          ! compacted depth, limited to the soil column (m)
+  real(rkind)                      :: depthWF_use                         ! wetting-front depth, clamped off the base of the soil (m)
   ! saturated area associated with variable storage capacity
   real(rkind)                      :: fracCap                             ! fraction of pore space filled with liquid water and ice (-)
   real(rkind)                      :: fInfRaw                             ! infiltrating area before imposing solution constraints (-)
@@ -1507,21 +1507,18 @@ subroutine update_volFracLiq_derivatives
        case(expLaw_profile)   ! K(z) = K_0*exp(-f*z), decays with depth but stays finite at the base of the soil
          hydCondWettingFront = surfaceSatHydCond * exp(-f_hydCond*depthWettingFront)
          dHydCondWF_dDepth   = -f_hydCond*hydCondWettingFront
-       ! floored power law, the same profile satHydCond builds: K(z) = K_0*(1 - min(z,zc)/R)**(zScale_TOPMODEL-1),
-       ! for zc = compactedDepth and R = refDepth. Below zc the conductivity is uniform, so the wetting front sees no gradient.
-       ! NOTE: zc < R always, so this never evaluates 0**(n-1) at the base of the soil
+       ! power law, the same profile satHydCond builds: K(z) = K_0*(1 - z/R)**(zScale_TOPMODEL-1) for
+       ! R = refDepth, decaying over the whole column and reaching zero at the base. It is not floored
+       ! below compactedDepth -- see the NOTE in satHydCond.
        case(powerLaw_profile)
          refDepth_use = total_soil_depth
          if (total_soil_depth < compactedDepth) refDepth_use = compactedDepth + 1._rkind ! as in satHydCond
-         cDepth_use   = min(compactedDepth, total_soil_depth)
-         if (depthWettingFront >= cDepth_use) then ! below the scaling zone, conductivity is uniform
-           hydCondWettingFront = surfaceSatHydCond * ( (1._rkind - cDepth_use/refDepth_use)**(zScale_TOPMODEL - 1._rkind) )
-           dHydCondWF_dDepth   = 0._rkind
-         else
-           hydCondWettingFront = surfaceSatHydCond * ( (1._rkind - depthWettingFront/refDepth_use)**(zScale_TOPMODEL - 1._rkind) )
-           dHydCondWF_dDepth   = -surfaceSatHydCond*(zScale_TOPMODEL - 1._rkind) &
-                                  * ( (1._rkind - depthWettingFront/refDepth_use)**(zScale_TOPMODEL - 2._rkind) )/refDepth_use
-         end if
+         ! clamp the wetting front off the base, where (1 - z/R)**(n-2) in the derivative is singular
+         depthWF_use = min(depthWettingFront, 0.99_rkind*refDepth_use)
+         hydCondWettingFront = surfaceSatHydCond * ( (1._rkind - depthWF_use/refDepth_use)**(zScale_TOPMODEL - 1._rkind) )
+         dHydCondWF_dDepth   = -surfaceSatHydCond*(zScale_TOPMODEL - 1._rkind) &
+                                * ( (1._rkind - depthWF_use/refDepth_use)**(zScale_TOPMODEL - 2._rkind) )/refDepth_use
+         if (depthWettingFront > depthWF_use) dHydCondWF_dDepth = 0._rkind
        case(constant)         ! K uniform with depth, so the wetting front sees the surface conductivity
          hydCondWettingFront = surfaceSatHydCond
          dHydCondWF_dDepth   = 0._rkind

--- a/build/source/engine/soilLiqFlux.f90
+++ b/build/source/engine/soilLiqFlux.f90
@@ -785,6 +785,8 @@ subroutine surfaceFlux(io_soilLiqFlux,in_surfaceFlux,io_surfaceFlux,out_surfaceF
   real(rkind)                      :: depthWettingFront                   ! depth to the wetting front (m)
   real(rkind)                      :: hydCondWettingFront                 ! hydraulic conductivity at the wetting front (m s-1)
   real(rkind)                      :: dHydCondWF_dDepth                   ! derivative in hydraulic conductivity at the wetting front w.r.t. its depth (s-1)
+  real(rkind)                      :: refDepth_use                        ! reference depth for the power-law profile scaling (m)
+  real(rkind)                      :: cDepth_use                          ! compacted depth, limited to the soil column (m)
   ! saturated area associated with variable storage capacity
   real(rkind)                      :: fracCap                             ! fraction of pore space filled with liquid water and ice (-)
   real(rkind)                      :: fInfRaw                             ! infiltrating area before imposing solution constraints (-)
@@ -1479,6 +1481,7 @@ subroutine update_volFracLiq_derivatives
    ! input: soil parameters
    zScale_TOPMODEL     => in_surfaceFlux % zScale_TOPMODEL     , & ! scaling factor used to describe decrease in hydraulic conductivity with depth (m)
    f_hydCond           => in_surfaceFlux % f_hydCond           , & ! decay rate of hydraulic conductivity with depth, exponential profile (m-1)
+   compactedDepth      => in_surfaceFlux % compactedDepth      , & ! depth where k_soil reaches the compacted value, power-law profile (m)
    rootingDepth        => in_surfaceFlux % rootingDepth        , & ! rooting depth (m)
    wettingFrontSuction => in_surfaceFlux % wettingFrontSuction , & ! Green-Ampt wetting front suction (m)
    mLayerDepth         => in_surfaceFlux % mLayerDepth         , & ! depth of each soil layer (m)
@@ -1504,10 +1507,21 @@ subroutine update_volFracLiq_derivatives
        case(expLaw_profile)   ! K(z) = K_0*exp(-f*z), decays with depth but stays finite at the base of the soil
          hydCondWettingFront = surfaceSatHydCond * exp(-f_hydCond*depthWettingFront)
          dHydCondWF_dDepth   = -f_hydCond*hydCondWettingFront
-       case(powerLaw_profile) ! K decreases with depth, to zero at the base of the soil
-         hydCondWettingFront = surfaceSatHydCond * ( (1._rkind - depthWettingFront/total_soil_depth)**(zScale_TOPMODEL - 1._rkind) )
-         dHydCondWF_dDepth   = -surfaceSatHydCond*(zScale_TOPMODEL - 1._rkind) &
-                                * ( (1._rkind - depthWettingFront/total_soil_depth)**(zScale_TOPMODEL - 2._rkind) )/total_soil_depth
+       ! floored power law, the same profile satHydCond builds: K(z) = K_0*(1 - min(z,zc)/R)**(zScale_TOPMODEL-1),
+       ! for zc = compactedDepth and R = refDepth. Below zc the conductivity is uniform, so the wetting front sees no gradient.
+       ! NOTE: zc < R always, so this never evaluates 0**(n-1) at the base of the soil
+       case(powerLaw_profile)
+         refDepth_use = total_soil_depth
+         if (total_soil_depth < compactedDepth) refDepth_use = compactedDepth + 1._rkind ! as in satHydCond
+         cDepth_use   = min(compactedDepth, total_soil_depth)
+         if (depthWettingFront >= cDepth_use) then ! below the scaling zone, conductivity is uniform
+           hydCondWettingFront = surfaceSatHydCond * ( (1._rkind - cDepth_use/refDepth_use)**(zScale_TOPMODEL - 1._rkind) )
+           dHydCondWF_dDepth   = 0._rkind
+         else
+           hydCondWettingFront = surfaceSatHydCond * ( (1._rkind - depthWettingFront/refDepth_use)**(zScale_TOPMODEL - 1._rkind) )
+           dHydCondWF_dDepth   = -surfaceSatHydCond*(zScale_TOPMODEL - 1._rkind) &
+                                  * ( (1._rkind - depthWettingFront/refDepth_use)**(zScale_TOPMODEL - 2._rkind) )/refDepth_use
+         end if
        case(constant)         ! K uniform with depth, so the wetting front sees the surface conductivity
          hydCondWettingFront = surfaceSatHydCond
          dHydCondWF_dDepth   = 0._rkind

--- a/build/source/engine/updatDiagn.f90
+++ b/build/source/engine/updatDiagn.f90
@@ -366,7 +366,7 @@ subroutine updatDiagn(&
         if(ixStateType(ixFullVector)==iname_liqCanopy .or. ixStateType(ixFullVector)==iname_liqLayer)then
           select case(ixDomainType)
             case(iname_veg);                           scalarCanopyWatTrial          = scalarCanopyLiqTrial          + scalarCanopyIceTrial
-            case(iname_snow, iname_lake, iname_glce);  mLayerVolFracWatTrial(iLayer) = mLayerVolFracLiqTrial(iLayer) + mLayerVolFracIceTrial(iLayer)*iden_ice/iden_water
+            case(iname_snow, iname_lake, iname_glce);  mLayerVolFracWatTrial(iLayer) = mLayerVolFracLiqTrial(iLayer) + mLayerVolFracIceTrial(iLayer)*(iden_ice/iden_water)
             case(iname_soil);                          mLayerVolFracWatTrial(iLayer) = mLayerVolFracLiqTrial(iLayer) + mLayerVolFracIceTrial(iLayer) ! no volume expansion
             case default; err=20; message=trim(message)//'expect case to be iname_veg, iname_snow, iname_lake, iname_soil, or iname_glce'; return
           end select

--- a/build/source/engine/updatDiagnWithPrime.f90
+++ b/build/source/engine/updatDiagnWithPrime.f90
@@ -407,8 +407,8 @@ subroutine updatDiagnWithPrime(&
                 scalarCanopyWatTrial          = scalarCanopyLiqTrial          + scalarCanopyIceTrial
                 scalarCanopyWatPrime          = scalarCanopyLiqPrime          + scalarCanopyIcePrime
             case(iname_snow, iname_lake, iname_glce)
-                mLayerVolFracWatTrial(iLayer) = mLayerVolFracLiqTrial(iLayer) + mLayerVolFracIceTrial(iLayer)*iden_ice/iden_water
-                mLayerVolFracWatPrime(iLayer) = mLayerVolFracLiqPrime(iLayer) + mLayerVolFracIcePrime(iLayer)*iden_ice/iden_water
+                mLayerVolFracWatTrial(iLayer) = mLayerVolFracLiqTrial(iLayer) + mLayerVolFracIceTrial(iLayer)*(iden_ice/iden_water)
+                mLayerVolFracWatPrime(iLayer) = mLayerVolFracLiqPrime(iLayer) + mLayerVolFracIcePrime(iLayer)*(iden_ice/iden_water)
             case(iname_soil)
                 mLayerVolFracWatTrial(iLayer) = mLayerVolFracLiqTrial(iLayer) + mLayerVolFracIceTrial(iLayer) ! no volume expansion
                 mLayerVolFracWatPrime(iLayer) = mLayerVolFracLiqPrime(iLayer) + mLayerVolFracIcePrime(iLayer)

--- a/build/source/engine/var_derive.f90
+++ b/build/source/engine/var_derive.f90
@@ -270,6 +270,7 @@ contains
  real(rkind)                     :: d1                  ! distance from lower-layer midpoint to interface (m)
  real(rkind)                     :: d2                  ! distance from interface to upper-layer midpoint (m)
  real(rkind)                     :: refDepth            ! reference depth for scaling (m)
+ logical(lgt)                    :: scaleProfile        ! .false. if the column ends exactly at compactedDepth (degenerate normalization)
  ! initialize error control
  err=0; message='satHydCond/'
  ! ----------------------------------------------------------------------------------
@@ -326,22 +327,23 @@ contains
       endif
     end do
   
-  ! power-law profile
+  ! power-law profile K(z) = k_soil*(1-z/refDepth)**(zScale_TOPMODEL-1), decays to 0 at base of the soil
   case(powerLaw_profile)
-    ! If total column is shallower than compactedDepth, use compactedDepth + 1 m as reference
-    if (iLayerHeight(nSnow+nLake+nSoil) < compactedDepth) then
-        refDepth = compactedDepth + 1._rkind
+    ! NOTE: the reference depth is the depth at which the conductivity is normalized to k_soil, which is the compactedDepth unless the soil column ends above that depth
+    if (iLayerHeight(nSnow+nLake+nSoil) < compactedDepth) then ! (1 - compactedDepth/refDepth)**(number<1) is NaN
+      refDepth = compactedDepth + 1._rkind
     else
-        refDepth = iLayerHeight(nSnow+nLake+nSoil)
+      refDepth = iLayerHeight(nSnow+nLake+nSoil)
     endif
+    scaleProfile = (compactedDepth < refDepth) ! normalization is degenerate when the column ends exactly at compactedDepth
 
     ! 1) Calculate scaled conductivities at layer midpoints first.
     do iLayer=(nSnow+nLake+1),(nSnow+nLake+nSoil)
       iSoil = iLayer-nSnow-nLake
-      if(mLayerHeight(iLayer) < compactedDepth)then    ! within the scaling zone (above compacted baseline depth)
+      if(scaleProfile)then
         midDepthScaleFactor = ( (1._rkind - mLayerHeight(iLayer)/refDepth)**(zScale_TOPMODEL - 1._rkind) ) / &
                               ( (1._rkind -       compactedDepth/refDepth)**(zScale_TOPMODEL - 1._rkind) )
-      else ! soil is fully compacted/unweathered at this depth
+      else
         midDepthScaleFactor = 1.0_rkind
       endif
       mLayerSatHydCond(iSoil)   = k_soil(iSoil)      * midDepthScaleFactor
@@ -351,10 +353,10 @@ contains
    ! 2) Compute interface conductivity from midpoint values.
    do iLayer=(nSnow+nLake),(nSnow+nLake+nSoil)
      iSoil = iLayer-nSnow-nLake
-     if(iLayerHeight(iLayer) < compactedDepth)then    ! within the scaling zone (above compacted baseline depth)
+     if(scaleProfile)then
        ifcDepthScaleFactor = ( (1._rkind - iLayerHeight(iLayer)/refDepth)**(zScale_TOPMODEL - 1._rkind) ) / &
                              ( (1._rkind -       compactedDepth/refDepth)**(zScale_TOPMODEL - 1._rkind) )
-     else ! soil is fully compacted/unweathered at this depth
+     else
        ifcDepthScaleFactor = 1.0_rkind
      endif
 

--- a/docs/assets/changes_fromV3Summa.txt
+++ b/docs/assets/changes_fromV3Summa.txt
@@ -253,3 +253,6 @@ AFTER tag of v4.0.0-exp-Sundials
       This rejects bigBuckt + pow_prof + GreenAmpt, previously legal and silently inconsistent, and the bigBucket deprecation warning now fires only for constant, where the GreenAmpt it advises is actually legal.
      computBaseflow keeps the classical (s/D)**zScale_TOPMODEL transmissivity (Ambroise et al. 1996), since with qTopmodl zScale_TOPMODEL is a recession-calibration parameter, not a soil property; constant is now its own case there (T linear in s).
 -61) Consistent association of the iden_ice/iden_water density ratio to (iden_ice/iden_water) because it is faster (inconsistent variations differ by 1 ULP), commit cde6aeeb Sep 11, 2026
+ 62) Fixed lateral flow HRUs within a GRU to run in cascade (topological) order instead of array order, commit 90edb489 Sep 11, 2026
+     The lateral outflow of an HRU is added to the inflow of its downslope HRU (downHRUindex) as each HRU is run, and the inflow
+      is zeroed at the start of every step, so a contributor run after its receiver would have its water silently dropped rather than delayed. 

--- a/docs/assets/changes_fromV3Summa.txt
+++ b/docs/assets/changes_fromV3Summa.txt
@@ -238,7 +238,7 @@ AFTER tag of v4.0.0-exp-Sundials
       ! pow_prof  ! power-law profile (original TOPMODEL-ish form)
       ! exp_prof  ! exponential profile, only for >=v4.1 (used internally for glacier debris; not allowed with groundwatr == qTopmodl)
      New parameter f_hydCond, decay rate of hydraulic conductivity with depth for the exponential profile (m-1), supraglacial debris and weathered shallow till values are default.
-      f_hydCond                 |       3.0000 |       0.1000 |      10.0000
+      f_hydCond                 |       0.7500 |       0.1000 |      10.0000
      SCOPE: only qTopmodl (and glacier domains) runs computBaseflow, and there exp_prof does not represent a shallow aquifer:
       classical Beven-Kirkby integrates K_0*exp(-f*z) to infinite depth, T(d) = (K_0/f)*exp(-f*d), still positive at the soil base,
       whereas exp_prof stops at an impermeable base at D, T(d) = (K_0/f)*[exp(-f*d) - exp(-f*D)], so T = 0 once the water table reaches D. 

--- a/docs/assets/changes_fromV3Summa.txt
+++ b/docs/assets/changes_fromV3Summa.txt
@@ -233,20 +233,15 @@ AFTER tag of v4.0.0-exp-Sundials
          Now recovers the surface value for any profile as surfaceHydCond*iLayerSatHydCond(0)/mLayerSatHydCond(1).
       2) Analytical-Jacobian consistency fix: for soil layers above the water table the baseflow is forced to zero (trSoil clamp), but the
          derivative matrix (dBaseflow_dVolLiq, dBaseflow_dWat, dBaseflow_dTk) still had non-zero rows for them. 
- 59) New exponential hydraulic conductivity profile, commits bb2b1344 and 5095074b Sep 10, 2026
+ 59) New exponential hydraulic conductivity profile, noting classical Beven-Kirkby transmissivity is exponential, commits bb2b1344 and 5095074b Sep 10, 2026
      New option for the hc_profile decision:
       ! constant   ! constant hydraulic conductivity with depth (not allowed with groundwatr == qTopmodl)
       ! pow_prof   ! power-law profile (original TOPMODEL-ish form)
-      ! exp_prof   ! exponential profile, K(z) = K_0*exp(-f*z), finite at the base of the soil
-     New parameter f_hydCond, decay rate of hydraulic conductivity with depth for the exponential profile (m-1), default 3 (1-5 m-1 for
-      supraglacial debris and weathered shallow till). Backwards compatible: defaults are supplied if the parameter is absent.
-     The TOPMODEL baseflow option (groundwatr == qTopmodl) now accepts exp_prof as well as pow_prof, since the baseflow transmissivity is
-      just the vertical integral of the conductivity profile. Glacier domains force exp_prof internally.
--60) Consistent association of the ice/water density ratio, Sep 11, 2026
-     iden_ice/iden_water (and iden_water/iden_ice) were written two ways across the code: grouped as x*(iden_ice/iden_water), which
-     folds to a single compile-time constant multiply, and chained as x*iden_ice/iden_water, which evaluates (x*917)/1000 at runtime.
-     917/1000 is not exactly representable in binary, so the two forms differ by one ULP. Both are equally accurate (two roundings
-     either way), but the grouped form is faster since iden_ice and iden_water are PARAMETERs, so the division is folded at compile
-     time rather than executed per call. This shifts results by ~1 ULP at each site, which then amplifies (see change 57), so it was applied identically to SummaDevelop
-     and to this branch in the same step. Verified afterwards: 11 of the 13 wrrPaper test cases remain bit-for-bit identical between
-     the two, the exceptions being the two groundwatr=qTopmodl cases, which differ only through change 58.
+      ! exp_prof   ! exponential profile, K(z) = K_0*exp(-f*z) finite at the base of the soil, only for >=v4.1
+     New parameter f_hydCond, decay rate of hydraulic conductivity with depth for the exponential profile (m-1), supraglacial debris and weathered shallow till values are default.
+      f_hydCond                 |       3.0000 |       0.1000 |      10.0000
+     The groundwatr == qTopmodl option now accepts exp_prof as well as pow_prof, since the baseflow transmissivity is just the vertical integral of the conductivity profile.
+     The profile shape is re-derived in three places (vs previous hard-coded power law from iLayerSatHydCond): satHydCond (the conductivity itself), the topmodel_GA max infiltration rate in soilLiqFlux (conductivity at wetting front), computBaseflow (transmissivity integral).
+-60) pow_prof conductivity profile floor below compactedDepth made consistent across satHydCond, topmodel_GA and computBaseflow, commit 8ae78ac2 Sep 11, 2026
+     The floor cannot be dropped, else at the bottom interface (1 - z/refDepth) is exactly 0, so 0**(zScale_TOPMODEL-1) is infinite for zScale_TOPMODEL < 1 (allowed to 0.1) and 0 above it.
+-61) Consistent association of the iden_ice/iden_water density ratio to (iden_ice/iden_water) because it is faster (inconsistent variations differ by 1 ULP), commit cde6aeeb Sep 11, 2026

--- a/docs/assets/changes_fromV3Summa.txt
+++ b/docs/assets/changes_fromV3Summa.txt
@@ -226,6 +226,7 @@ AFTER tag of v4.0.0-exp-Sundials
       and latMoraineWidth (GRU). All have defaults, so are only needed for glacier runs.
      maxSnowLayers is multiplied by 2.5 when any glacier is present, to allow firn development in the accumulation zone.
      The OpenWQ coupling was updated to be per (HRU, domain) rather than per HRU (see build/source/openwq), commit f16c3488 Sep 10, 2026.
+     Next Gen coupling was also updated.
 -58) Groundwater / TOPMODEL baseflow fixes in computBaseflow (decision groundwatr == qTopmodl), commit dca170cc Sep 10, 2026
       1) The transmissivity integrals are written in terms of the hydraulic conductivity at the soil surface, but the code was passing
          mLayerSatHydCondMP(1), which is the macropore conductivity at the first layer midpoint (already scaled by the depth profile).
@@ -241,4 +242,11 @@ AFTER tag of v4.0.0-exp-Sundials
       supraglacial debris and weathered shallow till). Backwards compatible: defaults are supplied if the parameter is absent.
      The TOPMODEL baseflow option (groundwatr == qTopmodl) now accepts exp_prof as well as pow_prof, since the baseflow transmissivity is
       just the vertical integral of the conductivity profile. Glacier domains force exp_prof internally.
-
+-60) Consistent association of the ice/water density ratio, Sep 11, 2026
+     iden_ice/iden_water (and iden_water/iden_ice) were written two ways across the code: grouped as x*(iden_ice/iden_water), which
+     folds to a single compile-time constant multiply, and chained as x*iden_ice/iden_water, which evaluates (x*917)/1000 at runtime.
+     917/1000 is not exactly representable in binary, so the two forms differ by one ULP. Both are equally accurate (two roundings
+     either way), but the grouped form is faster since iden_ice and iden_water are PARAMETERs, so the division is folded at compile
+     time rather than executed per call. This shifts results by ~1 ULP at each site, which then amplifies (see change 57), so it was applied identically to SummaDevelop
+     and to this branch in the same step. Verified afterwards: 11 of the 13 wrrPaper test cases remain bit-for-bit identical between
+     the two, the exceptions being the two groundwatr=qTopmodl cases, which differ only through change 58.

--- a/docs/assets/changes_fromV3Summa.txt
+++ b/docs/assets/changes_fromV3Summa.txt
@@ -233,15 +233,27 @@ AFTER tag of v4.0.0-exp-Sundials
          Now recovers the surface value for any profile as surfaceHydCond*iLayerSatHydCond(0)/mLayerSatHydCond(1).
       2) Analytical-Jacobian consistency fix: for soil layers above the water table the baseflow is forced to zero (trSoil clamp), but the
          derivative matrix (dBaseflow_dVolLiq, dBaseflow_dWat, dBaseflow_dTk) still had non-zero rows for them. 
- 59) New exponential hydraulic conductivity profile, noting classical Beven-Kirkby transmissivity is exponential, commits bb2b1344 and 5095074b Sep 10, 2026
-     New option for the hc_profile decision:
+ 59) New exponential hydraulic conductivity profile, used internally for glacier debris and future for SUMMA coupled to separate aquifer, commits bb2b1344 and 5095074b Sep 10, 2026
       ! constant   ! constant hydraulic conductivity with depth (not allowed with groundwatr == qTopmodl)
       ! pow_prof   ! power-law profile (original TOPMODEL-ish form)
-      ! exp_prof   ! exponential profile, K(z) = K_0*exp(-f*z) finite at the base of the soil, only for >=v4.1
+      ! exp_prof   ! exponential profile, only for >=v4.1 (used internally for glacier debris and future-proof selectable for an external aquifer)
      New parameter f_hydCond, decay rate of hydraulic conductivity with depth for the exponential profile (m-1), supraglacial debris and weathered shallow till values are default.
       f_hydCond                 |       3.0000 |       0.1000 |      10.0000
-     The groundwatr == qTopmodl option now accepts exp_prof as well as pow_prof, since the baseflow transmissivity is just the vertical integral of the conductivity profile.
-     The profile shape is re-derived in three places (vs previous hard-coded power law from iLayerSatHydCond): satHydCond (the conductivity itself), the topmodel_GA max infiltration rate in soilLiqFlux (conductivity at wetting front), computBaseflow (transmissivity integral).
--60) pow_prof conductivity profile floor below compactedDepth made consistent across satHydCond, topmodel_GA and computBaseflow, commit 8ae78ac2 Sep 11, 2026
-     The floor cannot be dropped, else at the bottom interface (1 - z/refDepth) is exactly 0, so 0**(zScale_TOPMODEL-1) is infinite for zScale_TOPMODEL < 1 (allowed to 0.1) and 0 above it.
+     SCOPE: exp_prof is not classical Beven-Kirkby. B-K integrates K_0*exp(-f*z) to infinite depth, T(d) = (K_0/f)*exp(-f*d), still
+      positive with the water table at the soil base; that deep indefinite store is what makes it a shallow aquifer. exp_prof
+      integrates to a finite impermeable base at D, T(d) = (K_0/f)*[exp(-f*d) - exp(-f*D)], so T = 0 there. It therefore means
+      lateral flow over an impermeable base with no aquifer beneath: glacier debris over ice, or soil over a separately modelled
+      aquifer (e.g. MODFLOW). The dropped tail exp(-f*D) is 22-41% of T_0 for 0.3-0.5 m debris with f = 3, but 6e-6 for
+      a 4 m soil column, so it only matters for shallow columns. So exp_prof is rejected by mDecisions for now.
+     The profile shape is re-derived in three places (vs previous hard-coded power law from iLayerSatHydCond): satHydCond (the conductivity itself), the topmodel_GA max infiltration rate in soilLiqFlux (conductivity at wetting front), computBaseflow (transmissivity).
+     Only exp_prof is consistent across all three. The re-derivation deliberately keeps the pow_prof inconsistency: computBaseflow
+      stays on the classical calibrated transmissivity and so does not match the compactedDepth floor satHydCond applies to the
+      conductivity (see change 60).
+-60) pow_prof conductivity floor below compactedDepth carried into the topmodel_GA infiltration rate, and the infRateMax check re-keyed on hc_profile, commit 8ae78ac2 Sep 11, 2026
+     topmodel_GA re-derived the unfloored power law while satHydCond floors below compactedDepth; both are the vertical conductivity at a depth, so topmodel_GA now uses satHydCond's shape. 
+     Note: The floor cannot be dropped instead: at the bottom interface 0**(zScale_TOPMODEL-1) is infinite for zScale_TOPMODEL < 1 (allowed to 0.1) and exactly 0 above it.
+      GreenAmpt vs topmodel_GA is about depth-varying conductivity, an hc_profile property not a groundwatr one, so the check is re-keyed: pow_prof/exp_prof need topmodel_GA (or noInfExc), 
+      constant with topmodel_GA only warns since it is the backwards-compatible default. 
+      This rejects bigBuckt + pow_prof + GreenAmpt, previously legal and silently inconsistent, and the bigBucket deprecation warning now fires only for constant, where the GreenAmpt it advises is actually legal.
+     computBaseflow keeps the classical (s/D)**zScale_TOPMODEL transmissivity (Ambroise et al. 1996), since with qTopmodl zScale_TOPMODEL is a recession-calibration parameter, not a soil property; constant is now its own case there (T linear in s).
 -61) Consistent association of the iden_ice/iden_water density ratio to (iden_ice/iden_water) because it is faster (inconsistent variations differ by 1 ULP), commit cde6aeeb Sep 11, 2026

--- a/docs/assets/changes_fromV3Summa.txt
+++ b/docs/assets/changes_fromV3Summa.txt
@@ -234,21 +234,17 @@ AFTER tag of v4.0.0-exp-Sundials
       2) Analytical-Jacobian consistency fix: for soil layers above the water table the baseflow is forced to zero (trSoil clamp), but the
          derivative matrix (dBaseflow_dVolLiq, dBaseflow_dWat, dBaseflow_dTk) still had non-zero rows for them. 
  59) New exponential hydraulic conductivity profile, used internally for glacier debris and future for SUMMA coupled to separate aquifer, commits bb2b1344 and 5095074b Sep 10, 2026
-      ! constant   ! constant hydraulic conductivity with depth (not allowed with groundwatr == qTopmodl)
-      ! pow_prof   ! power-law profile (original TOPMODEL-ish form)
-      ! exp_prof   ! exponential profile, only for >=v4.1 (used internally for glacier debris and future-proof selectable for an external aquifer)
+      ! constant  ! constant hydraulic conductivity with depth (not allowed with groundwatr == qTopmodl)
+      ! pow_prof  ! power-law profile (original TOPMODEL-ish form)
+      ! exp_prof  ! exponential profile, only for >=v4.1 (used internally for glacier debris; not allowed with groundwatr == qTopmodl)
      New parameter f_hydCond, decay rate of hydraulic conductivity with depth for the exponential profile (m-1), supraglacial debris and weathered shallow till values are default.
       f_hydCond                 |       3.0000 |       0.1000 |      10.0000
-     SCOPE: exp_prof is not classical Beven-Kirkby. B-K integrates K_0*exp(-f*z) to infinite depth, T(d) = (K_0/f)*exp(-f*d), still
-      positive with the water table at the soil base; that deep indefinite store is what makes it a shallow aquifer. exp_prof
-      integrates to a finite impermeable base at D, T(d) = (K_0/f)*[exp(-f*d) - exp(-f*D)], so T = 0 there. It therefore means
-      lateral flow over an impermeable base with no aquifer beneath: glacier debris over ice, or soil over a separately modelled
-      aquifer (e.g. MODFLOW). The dropped tail exp(-f*D) is 22-41% of T_0 for 0.3-0.5 m debris with f = 3, but 6e-6 for
-      a 4 m soil column, so it only matters for shallow columns. So exp_prof is rejected by mDecisions for now.
+     SCOPE: only qTopmodl (and glacier domains) runs computBaseflow, and there exp_prof does not represent a shallow aquifer:
+      classical Beven-Kirkby integrates K_0*exp(-f*z) to infinite depth, T(d) = (K_0/f)*exp(-f*d), still positive at the soil base,
+      whereas exp_prof stops at an impermeable base at D, T(d) = (K_0/f)*[exp(-f*d) - exp(-f*D)], so T = 0 once the water table reaches D. 
+      That suits debris over ice, handled internally, or soil over a deeper aquifer.
      The profile shape is re-derived in three places (vs previous hard-coded power law from iLayerSatHydCond): satHydCond (the conductivity itself), the topmodel_GA max infiltration rate in soilLiqFlux (conductivity at wetting front), computBaseflow (transmissivity).
-     Only exp_prof is consistent across all three. The re-derivation deliberately keeps the pow_prof inconsistency: computBaseflow
-      stays on the classical calibrated transmissivity and so does not match the compactedDepth floor satHydCond applies to the
-      conductivity (see change 60).
+     Only exp_prof is consistent across all three. The re-derivation deliberately keeps the pow_prof inconsistency: computBaseflow stays on the classical calibrated transmissivity and so does not match the compactedDepth floor satHydCond applies to the conductivity.
 -60) pow_prof conductivity floor below compactedDepth carried into the topmodel_GA infiltration rate, and the infRateMax check re-keyed on hc_profile, commit 8ae78ac2 Sep 11, 2026
      topmodel_GA re-derived the unfloored power law while satHydCond floors below compactedDepth; both are the vertical conductivity at a depth, so topmodel_GA now uses satHydCond's shape. 
      Note: The floor cannot be dropped instead: at the bottom interface 0**(zScale_TOPMODEL-1) is infinite for zScale_TOPMODEL < 1 (allowed to 0.1) and exactly 0 above it.

--- a/docs/assets/changes_fromV3Summa.txt
+++ b/docs/assets/changes_fromV3Summa.txt
@@ -200,6 +200,9 @@ AFTER tag of v4.0.0-exp-Sundials
 -52) If scalar solution fails on a snow layer, exit and merge snow layers if failure was from too much energy going into top layer (previous behavior was code failure), commit 7c46a507 May 5, 2026
      Also changed the number of times it checks the brackets for scalar solution from 100 to 10 since usually by 2 it's found the bracket or not.
 -53) Fix power profile hydraulic conductivity if total soil depth less than compactedDepth, and rewrite to make smooth profile if k_soil differs across layers and take into account differing layer thicknesses (use harmonic mean), commit 8119be7c May 29, 2026
+     Bugfix Sep 11, 2026: this had also floored the conductivity at k_soil below compactedDepth, so the power law no longer decayed to zero at the base of
+      the soil, which is the Beven-Kirkby premise the qTopmodl transmissivity integrates. Floor removed, and the v3 guard for a column ending exactly at
+      compactedDepth restored (the normalization 0**(zScale_TOPMODEL-1) is otherwise a divide by zero). Belongs on master as well.
 -54) Fix baseflow derivatives (decision groundwatr == qTopmodl) commit 84009cb6, Jun 20, 2026
 -55) Turn off (smoothly) condensation into saturated soil and infiltration into over-pressured soil with no water exit (no flux BC and no lateral flow), last bit of sat soil, commits around 87967f22 Jul 22, 2026
  56) Remove deprecated moisture-based Richards' equation, f_Richards decision still can be included but does not do anything but mixed form, commits around b99de74f	Jul 22, 2026
@@ -244,14 +247,11 @@ AFTER tag of v4.0.0-exp-Sundials
       whereas exp_prof stops at an impermeable base at D, T(d) = (K_0/f)*[exp(-f*d) - exp(-f*D)], so T = 0 once the water table reaches D. 
       That suits debris over ice, handled internally, or soil over a deeper aquifer.
      The profile shape is re-derived in three places (vs previous hard-coded power law from iLayerSatHydCond): satHydCond (the conductivity itself), the topmodel_GA max infiltration rate in soilLiqFlux (conductivity at wetting front), computBaseflow (transmissivity).
-     Only exp_prof is consistent across all three. The re-derivation deliberately keeps the pow_prof inconsistency: computBaseflow stays on the classical calibrated transmissivity and so does not match the compactedDepth floor satHydCond applies to the conductivity.
--60) pow_prof conductivity floor below compactedDepth carried into the topmodel_GA infiltration rate, and the infRateMax check re-keyed on hc_profile, commit 8ae78ac2 Sep 11, 2026
-     topmodel_GA re-derived the unfloored power law while satHydCond floors below compactedDepth; both are the vertical conductivity at a depth, so topmodel_GA now uses satHydCond's shape. 
-     Note: The floor cannot be dropped instead: at the bottom interface 0**(zScale_TOPMODEL-1) is infinite for zScale_TOPMODEL < 1 (allowed to 0.1) and exactly 0 above it.
-      GreenAmpt vs topmodel_GA is about depth-varying conductivity, an hc_profile property not a groundwatr one, so the check is re-keyed: pow_prof/exp_prof need topmodel_GA (or noInfExc), 
-      constant with topmodel_GA only warns since it is the backwards-compatible default. 
-      This rejects bigBuckt + pow_prof + GreenAmpt, previously legal and silently inconsistent, and the bigBucket deprecation warning now fires only for constant, where the GreenAmpt it advises is actually legal.
-     computBaseflow keeps the classical (s/D)**zScale_TOPMODEL transmissivity (Ambroise et al. 1996), since with qTopmodl zScale_TOPMODEL is a recession-calibration parameter, not a soil property; constant is now its own case there (T linear in s).
+     After change 60 all three agree for pow_prof as well as exp_prof.
+-60) topmodel_GA changes: infiltration rate now follows hc_profile, and infRateMax is re-keyed on hc_profile (not groundwatr), commit 8ae78ac2 Sep 11, 2026
+     It now uses satHydCond's conductivity-depth shape instead of a hand-derived one, so both and computBaseflow agree.
+     pow_prof/exp_prof now require topmodel_GA (or noInfExc); constant only warns with topmodel_GA.
+     Newly rejected (previously silent no-ops): bigBuckt+pow_prof+GreenAmpt, and presHead+pow_prof (zero conductivity at the soil base drove no drainage - use exp_prof).
 -61) Consistent association of the iden_ice/iden_water density ratio to (iden_ice/iden_water) because it is faster (inconsistent variations differ by 1 ULP), commit cde6aeeb Sep 11, 2026
  62) Fixed lateral flow HRUs within a GRU to run in cascade (topological) order instead of array order, commit 90edb489 Sep 11, 2026
      The lateral outflow of an HRU is added to the inflow of its downslope HRU (downHRUindex) as each HRU is run, and the inflow

--- a/docs/configuration/SUMMA_model_decisions.md
+++ b/docs/configuration/SUMMA_model_decisions.md
@@ -234,7 +234,7 @@ See also [`spatial_gw`](#spatial_gw), which sets whether the store is per column
 | Option | Description |
 |---|---|
 | constant | saturated hydraulic conductivity constant with depth |
-| pow_prof | power-law decrease with depth, floored at the compacted value below `compactedDepth` |
+| pow_prof | power-law decrease with depth, normalized to `k_soil` at `compactedDepth` and reaching zero at the base of the soil |
 | exp_prof | exponential decrease with depth, `K(z) = k_soil * exp(-f_hydCond * z)`, finite at the base of the soil |
 
 `constant` means a homogeneous column, so it pairs with [`infRateMax`](#infratemax) `GreenAmpt`. `pow_prof` and `exp_prof` vary with
@@ -244,8 +244,11 @@ depth and so require `topmodel_GA` (or `noInfExc`), which evaluates the conducti
 `exp_prof` instead stops at an impermeable base, which suits glacier debris over ice or soil over an external aquifer, and is not
 yet selectable with `qTopmodl`. Glacier domains use it internally whatever this decision is set to.
 
-The decay rate for `exp_prof` is the parameter `f_hydCond` (m-1), default 3, a supraglacial-debris value; deep soil columns want a
-smaller one, since 3 m-1 leaves only ~1e-5 of the surface conductivity at 4 m.
+`pow_prof` cannot be used with [`bcLowrSoiH`](#bclowrsoih) `presHead`: its conductivity is exactly zero at the base of the soil, so a
+prescribed head can drive no drainage. Use `exp_prof`, which decays with depth but stays finite there.
+
+The decay rate for `exp_prof` is the parameter `f_hydCond` (m-1), default 0.75, a soil-column value leaving ~5% of the surface
+conductivity at 4 m. Supraglacial debris is 1-5 m-1 over a 0.3-1 m depth, so glacier runs should set it explicitly.
 
 <a id="bcupprtdyn"></a>
 ## 19. bcUpprTdyn — upper boundary condition, thermodynamics

--- a/docs/configuration/SUMMA_model_decisions.md
+++ b/docs/configuration/SUMMA_model_decisions.md
@@ -234,8 +234,18 @@ See also [`spatial_gw`](#spatial_gw), which sets whether the store is per column
 | Option | Description |
 |---|---|
 | constant | saturated hydraulic conductivity constant with depth |
-| pow_prof | power-law decrease of saturated hydraulic conductivity with depth |
-| exp_prof | exponential decrease of saturated hydraulic conductivity with depth |
+| pow_prof | power-law decrease with depth, floored at the compacted value below `compactedDepth` |
+| exp_prof | exponential decrease with depth, `K(z) = k_soil * exp(-f_hydCond * z)`, finite at the base of the soil |
+
+`constant` means a homogeneous column, so it pairs with [`infRateMax`](#infratemax) `GreenAmpt`. `pow_prof` and `exp_prof` vary with
+depth and so require `topmodel_GA` (or `noInfExc`), which evaluates the conductivity at the wetting front.
+
+[`groundwatr`](#groundwatr) `qTopmodl` requires `pow_prof`, the only option whose transmissivity represents a shallow aquifer.
+`exp_prof` instead stops at an impermeable base, which suits glacier debris over ice or soil over an external aquifer, and is not
+yet selectable with `qTopmodl`. Glacier domains use it internally whatever this decision is set to.
+
+The decay rate for `exp_prof` is the parameter `f_hydCond` (m-1), default 3, a supraglacial-debris value; deep soil columns want a
+smaller one, since 3 m-1 leaves only ~1e-5 of the surface conductivity at 4 m.
 
 <a id="bcupprtdyn"></a>
 ## 19. bcUpprTdyn — upper boundary condition, thermodynamics
@@ -437,9 +447,12 @@ With the `itertive` alias, the value is forced to `closedForm` for backward comp
 
 | Option | Description |
 |---|---|
-| topmodel_GA | Green-Ampt with a TOPMODEL-based conductivity rate (default; also selected by `notPopulatedYet` when `num_method = itertive`) |
+| topmodel_GA | Green-Ampt with the [`hc_profile`](#hc_profile) conductivity evaluated at the wetting front (default; also selected by `notPopulatedYet` when `num_method = itertive`) |
 | GreenAmpt | Green-Ampt maximum infiltration rate |
 | noInfExc | maximum infiltration rate set very high, effectively disabling infiltration-excess runoff (saturation-excess runoff can still occur) |
+
+This must match [`hc_profile`](#hc_profile): a depth-varying profile requires `topmodel_GA` or `noInfExc`, and `constant` with
+`topmodel_GA` gives a deprecation warning.
 
 <a id="surfrun_se"></a>
 ## 42. surfRun_SE — saturation-excess surface runoff

--- a/test_ngen/domain_provo/settings/SUMMA/modelDecisions.txt
+++ b/test_ngen/domain_provo/settings/SUMMA/modelDecisions.txt
@@ -83,7 +83,7 @@ write_buff                      writePerStep    ! (31) method used to write mode
 ! (09) choice of hydraulic conductivity profile
 ! constant  ! constant hydraulic conductivity with depth (not allowed with groundwatr == qTopmodl)
 ! pow_prof  ! power-law profile (original TOPMODEL-ish form)
-! exp_prof  ! exponential profile, only for >=v4.1 (used internally for glacier debris and future-proof selectable for an external aquifer)
+! exp_prof  ! exponential profile, only for >=v4.1 (used internally for glacier debris; not allowed with groundwatr == qTopmodl)
 ! -----------------------------------------------------------------------------------------------
 ! (10) choice of upper boundary conditions for thermodynamics
 ! presTemp  ! prescribed temperature

--- a/test_ngen/domain_provo/settings/SUMMA/modelDecisions.txt
+++ b/test_ngen/domain_provo/settings/SUMMA/modelDecisions.txt
@@ -81,9 +81,9 @@ write_buff                      writePerStep    ! (31) method used to write mode
 ! noXplict  ! no explicit groundwater parameterization
 ! -----------------------------------------------------------------------------------------------
 ! (09) choice of hydraulic conductivity profile
-! constant  ! constant hydraulic conductivity with depth
-! pow_prof  ! power-law profile
-! exp_prof  ! exponential profile, only for >=v4.1
+! constant  ! constant hydraulic conductivity with depth (not allowed with groundwatr == qTopmodl)
+! pow_prof  ! power-law profile (original TOPMODEL-ish form)
+! exp_prof  ! exponential profile, K(z) = K_0*exp(-f*z) finite at the base of the soil, only for >=v4.1
 ! -----------------------------------------------------------------------------------------------
 ! (10) choice of upper boundary conditions for thermodynamics
 ! presTemp  ! prescribed temperature

--- a/test_ngen/domain_provo/settings/SUMMA/modelDecisions.txt
+++ b/test_ngen/domain_provo/settings/SUMMA/modelDecisions.txt
@@ -83,7 +83,7 @@ write_buff                      writePerStep    ! (31) method used to write mode
 ! (09) choice of hydraulic conductivity profile
 ! constant  ! constant hydraulic conductivity with depth (not allowed with groundwatr == qTopmodl)
 ! pow_prof  ! power-law profile (original TOPMODEL-ish form)
-! exp_prof  ! exponential profile, K(z) = K_0*exp(-f*z) finite at the base of the soil, only for >=v4.1
+! exp_prof  ! exponential profile, only for >=v4.1 (used internally for glacier debris and future-proof selectable for an external aquifer)
 ! -----------------------------------------------------------------------------------------------
 ! (10) choice of upper boundary conditions for thermodynamics
 ! presTemp  ! prescribed temperature

--- a/test_ngen/gauge_01073000/settings/SUMMA/modelDecisions.txt
+++ b/test_ngen/gauge_01073000/settings/SUMMA/modelDecisions.txt
@@ -83,7 +83,7 @@ write_buff                      writePerStep    ! (31) method used to write mode
 ! (09) choice of hydraulic conductivity profile
 ! constant  ! constant hydraulic conductivity with depth (not allowed with groundwatr == qTopmodl)
 ! pow_prof  ! power-law profile (original TOPMODEL-ish form)
-! exp_prof  ! exponential profile, only for >=v4.1 (used internally for glacier debris and future-proof selectable for an external aquifer)
+! exp_prof  ! exponential profile, only for >=v4.1 (used internally for glacier debris; not allowed with groundwatr == qTopmodl)
 ! -----------------------------------------------------------------------------------------------
 ! (10) choice of upper boundary conditions for thermodynamics
 ! presTemp  ! prescribed temperature

--- a/test_ngen/gauge_01073000/settings/SUMMA/modelDecisions.txt
+++ b/test_ngen/gauge_01073000/settings/SUMMA/modelDecisions.txt
@@ -81,9 +81,9 @@ write_buff                      writePerStep    ! (31) method used to write mode
 ! noXplict  ! no explicit groundwater parameterization
 ! -----------------------------------------------------------------------------------------------
 ! (09) choice of hydraulic conductivity profile
-! constant  ! constant hydraulic conductivity with depth
-! pow_prof  ! power-law profile
-! exp_prof  ! exponential profile, only for >=v4.1
+! constant  ! constant hydraulic conductivity with depth (not allowed with groundwatr == qTopmodl)
+! pow_prof  ! power-law profile (original TOPMODEL-ish form)
+! exp_prof  ! exponential profile, K(z) = K_0*exp(-f*z) finite at the base of the soil, only for >=v4.1
 ! -----------------------------------------------------------------------------------------------
 ! (10) choice of upper boundary conditions for thermodynamics
 ! presTemp  ! prescribed temperature

--- a/test_ngen/gauge_01073000/settings/SUMMA/modelDecisions.txt
+++ b/test_ngen/gauge_01073000/settings/SUMMA/modelDecisions.txt
@@ -83,7 +83,7 @@ write_buff                      writePerStep    ! (31) method used to write mode
 ! (09) choice of hydraulic conductivity profile
 ! constant  ! constant hydraulic conductivity with depth (not allowed with groundwatr == qTopmodl)
 ! pow_prof  ! power-law profile (original TOPMODEL-ish form)
-! exp_prof  ! exponential profile, K(z) = K_0*exp(-f*z) finite at the base of the soil, only for >=v4.1
+! exp_prof  ! exponential profile, only for >=v4.1 (used internally for glacier debris and future-proof selectable for an external aquifer)
 ! -----------------------------------------------------------------------------------------------
 ! (10) choice of upper boundary conditions for thermodynamics
 ! presTemp  ! prescribed temperature


### PR DESCRIPTION
This breaks bit-4-bit matching in laugh test topmodel, but cleans up the lateral flow:
-58) Groundwater / TOPMODEL baseflow fixes in computBaseflow (decision groundwatr == qTopmodl), commit dca170cc Sep 10, 2026
      1) The transmissivity integrals are written in terms of the hydraulic conductivity at the soil surface, but the code was passing
         mLayerSatHydCondMP(1), which is the macropore conductivity at the first layer midpoint (already scaled by the depth profile).
         Now recovers the surface value for any profile as surfaceHydCond*iLayerSatHydCond(0)/mLayerSatHydCond(1).
      2) Analytical-Jacobian consistency fix: for soil layers above the water table the baseflow is forced to zero (trSoil clamp), but the
         derivative matrix (dBaseflow_dVolLiq, dBaseflow_dWat, dBaseflow_dTk) still had non-zero rows for them. 
 59) New exponential hydraulic conductivity profile, used internally for glacier debris and future for SUMMA coupled to separate aquifer, commits bb2b1344 and 5095074b Sep 10, 2026
      ! constant  ! constant hydraulic conductivity with depth (not allowed with groundwatr == qTopmodl)
      ! pow_prof  ! power-law profile (original TOPMODEL-ish form)
      ! exp_prof  ! exponential profile, only for >=v4.1 (used internally for glacier debris; not allowed with groundwatr == qTopmodl)
     New parameter f_hydCond, decay rate of hydraulic conductivity with depth for the exponential profile (m-1), supraglacial debris and weathered shallow till values are default.
      f_hydCond                 |       0.7500 |       0.1000 |      10.0000
     SCOPE: only qTopmodl (and glacier domains) runs computBaseflow, and there exp_prof does not represent a shallow aquifer:
      classical Beven-Kirkby integrates K_0*exp(-f*z) to infinite depth, T(d) = (K_0/f)*exp(-f*d), still positive at the soil base,
      whereas exp_prof stops at an impermeable base at D, T(d) = (K_0/f)*[exp(-f*d) - exp(-f*D)], so T = 0 once the water table reaches D. 
      That suits debris over ice, handled internally, or soil over a deeper aquifer.
     The profile shape is re-derived in three places (vs previous hard-coded power law from iLayerSatHydCond): satHydCond (the conductivity itself), the topmodel_GA max infiltration rate in soilLiqFlux (conductivity at wetting front), computBaseflow (transmissivity).
     After change 60 all three agree for pow_prof as well as exp_prof.
-60) topmodel_GA changes: infiltration rate now follows hc_profile, and infRateMax is re-keyed on hc_profile (not groundwatr), commit 8ae78ac2 Sep 11, 2026
     It now uses satHydCond's conductivity-depth shape instead of a hand-derived one, so both and computBaseflow agree.
     pow_prof/exp_prof now require topmodel_GA (or noInfExc); constant only warns with topmodel_GA.
     Newly rejected (previously silent no-ops): bigBuckt+pow_prof+GreenAmpt, and presHead+pow_prof (zero conductivity at the soil base drove no drainage - use exp_prof).
-61) Consistent association of the iden_ice/iden_water density ratio to (iden_ice/iden_water) because it is faster (inconsistent variations differ by 1 ULP), commit cde6aeeb Sep 11, 2026
 62) Fixed lateral flow HRUs within a GRU to run in cascade (topological) order instead of array order, commit 90edb489 Sep 11, 2026
     The lateral outflow of an HRU is added to the inflow of its downslope HRU (downHRUindex) as each HRU is run, and the inflow
      is zeroed at the start of every step, so a contributor run after its receiver would have its water silently dropped rather than delayed. 